### PR TITLE
feat: v2.1.0 — Welford + linalg, p-value bug fixes, MIT relicense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 # Cursor agent state and cache
 .cursor/
+
+# Local cross-validation harness (numpy/scipy)
+/validation/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## [v2.1.0](https://github.com/Lsh0x/rs-stats/tree/v2.1.0)
+
+**License:** the project is now MIT-licensed (was GPL-3.0).
+
+**New:**
+
+- `prob::welford` — numerically stable online estimators: `Welford` (scalar),
+  `WelfordVector` (per-axis), `WelfordCovariance` (full covariance matrix
+  with zero per-call allocation via persistent scratch buffer).
+  `Welford::pop` for subtractive updates, `merge` (Chan 1979) on all three
+  for distributed accumulation.
+- `utils::linalg` — small dense linear algebra: `invert` /
+  `invert_with_ridge` (Gauss-Jordan with partial pivoting, single shared
+  augmented-matrix kernel), `mahalanobis_sq` and zero-allocation
+  `mahalanobis_sq_into` variant for hot per-row scoring loops.
+- `WelfordVector::variance_into` / `std_dev_into` — zero-allocation
+  per-axis variants.
+- `distributions::fitting::ks_test_with_scratch` /
+  `ks_test_discrete_with_scratch` — caller-provided buffer variants of the
+  Kolmogorov-Smirnov tests; `fit_all` / `fit_all_verbose` /
+  `fit_all_discrete` / `fit_all_discrete_verbose` now reuse a single
+  scratch buffer instead of allocating one per candidate.
+
+**Fixed bugs:**
+
+- `t_test::{one_sample, two_sample (Welch), paired}_t_test` returned
+  incorrect p-values (often `1.0`) due to a broken in-file
+  `incomplete_beta`. Now delegates to the canonical
+  `utils::special_functions::regularized_incomplete_beta`.
+- `anova::one_way_anova` returned `0.0` p-values for moderate F-statistics
+  because of a buggy in-file rational approximation. Now uses the
+  canonical incomplete beta.
+- `chi_square::{goodness_of_fit, independence}` used the Wilson-Hilferty
+  normal approximation (~0.3 % error). Now uses the canonical
+  `regularized_incomplete_gamma` for the χ² survival function (matches
+  `scipy.stats.chi2.sf` to ~1e-12).
+- `normal_inverse_cdf` returned wildly incorrect values in the lower / upper
+  tails (p ≤ 0.02425, p ≥ 0.97575). Acklam's rational approximation is now
+  applied as published, without the spurious `-t` shift.
+- `prob::erf` upgraded to track scipy to ~1e-12 (was ~1.5e-7 max error
+  via Abramowitz-Stegun 7.1.26). Internally delegates to
+  `regularized_incomplete_gamma(0.5, x²)`.
+
+**Performance:**
+
+- `LogNormal::fit` — single-pass online mean+variance on `ln(x)` instead
+  of allocating an intermediate `Vec<f64>`.
+- `linalg::invert_with_ridge` — builds the augmented `[A+λI | I]` matrix
+  in one pass, removing the prior `matrix.to_vec()` clone (saves one
+  `Vec<f64>` of length `dim²` per call).
+- `fit_all` and friends — pre-allocated capacity hints + shared KS
+  scratch buffer (10× fewer allocations on the continuous fit path,
+  4× fewer on the discrete one).
+
+**Validation:**
+
+- All distribution PDF/CDF/PPF, hypothesis test statistics + p-values,
+  Welford estimators, special functions and linalg primitives are now
+  cross-validated against numpy / scipy / sklearn via a local harness in
+  `validation/` (gitignored). 35 invariants tracked; matches scipy to
+  1e-9 / 1e-12 on most paths.
+
+[Full Changelog](https://github.com/Lsh0x/rs-stats/compare/v2.0.3...v2.1.0)
+
 ## [Unreleased](https://github.com/Lsh0x/rs-stats/tree/HEAD)
 
 [Full Changelog](https://github.com/Lsh0x/rs-stats/compare/3b6164864800773f1e475b62ec24a04d2cc76930...HEAD)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rs-stats"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rs-stats"
-version = "2.0.3"
+version = "2.1.0"
 authors = ["LSH <github@lsh.tech>"]
 edition = "2024"
 description = "Statistics library in rust"
-license = "GPL-3.0"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 LSH <github@lsh.tech>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.3-green.svg)](https://crates.io/crates/rs-stats)
-[![Tests](https://img.shields.io/badge/tests-343%20passing-brightgreen.svg)](https://github.com/lsh0x/rs-stats/actions)
+[![Version](https://img.shields.io/badge/version-2.1.0-green.svg)](https://crates.io/crates/rs-stats)
+[![Tests](https://img.shields.io/badge/tests-368%20passing-brightgreen.svg)](https://github.com/lsh0x/rs-stats/actions)
 [![CI](https://github.com/lsh0x/rs-stats/workflows/CI/badge.svg)](https://github.com/lsh0x/rs-stats/actions)
 [![Docs](https://docs.rs/rs-stats/badge.svg)](https://docs.rs/rs-stats)
 [![Crates.io](https://img.shields.io/crates/v/rs-stats.svg)](https://crates.io/crates/rs-stats)

--- a/src/distributions/fitting.rs
+++ b/src/distributions/fitting.rs
@@ -122,19 +122,31 @@ pub struct KsResult {
 ///
 /// Uses the Kolmogorov distribution for the p-value approximation.
 pub fn ks_test(data: &[f64], cdf: impl Fn(f64) -> f64) -> KsResult {
-    let n = data.len();
+    let mut buf = Vec::with_capacity(data.len());
+    buf.extend_from_slice(data);
+    ks_test_with_scratch(&mut buf, cdf)
+}
+
+/// Zero-allocation variant of [`ks_test`] — sorts the caller-provided
+/// buffer in place and uses it as the working copy.
+///
+/// `scratch` must already contain the data to test (the function does not
+/// copy from anywhere). This lets callers reuse one buffer across many KS
+/// evaluations: see [`fit_all`] which fits 10 candidates from a single
+/// `&[f64]` input.
+pub fn ks_test_with_scratch(scratch: &mut [f64], cdf: impl Fn(f64) -> f64) -> KsResult {
+    let n = scratch.len();
     if n == 0 {
         return KsResult {
             statistic: 0.0,
             p_value: 1.0,
         };
     }
-    let mut sorted = data.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let nf = n as f64;
     let mut d = 0.0_f64;
-    for (i, &x) in sorted.iter().enumerate() {
+    for (i, &x) in scratch.iter().enumerate() {
         let f = cdf(x);
         let upper = (i + 1) as f64 / nf;
         let lower = i as f64 / nf;
@@ -151,19 +163,28 @@ pub fn ks_test(data: &[f64], cdf: impl Fn(f64) -> f64) -> KsResult {
 
 /// KS test for discrete distributions (uses PMF-based CDF on integer grid).
 pub fn ks_test_discrete(data: &[f64], cdf: impl Fn(u64) -> f64) -> KsResult {
-    let n = data.len();
+    let mut buf = Vec::with_capacity(data.len());
+    buf.extend_from_slice(data);
+    ks_test_discrete_with_scratch(&mut buf, cdf)
+}
+
+/// Zero-allocation variant of [`ks_test_discrete`].
+pub fn ks_test_discrete_with_scratch(
+    scratch: &mut [f64],
+    cdf: impl Fn(u64) -> f64,
+) -> KsResult {
+    let n = scratch.len();
     if n == 0 {
         return KsResult {
             statistic: 0.0,
             p_value: 1.0,
         };
     }
-    let mut sorted = data.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let nf = n as f64;
     let mut d = 0.0_f64;
-    for (i, &x) in sorted.iter().enumerate() {
+    for (i, &x) in scratch.iter().enumerate() {
         let k = x.round() as u64;
         let f = cdf(k);
         let upper = (i + 1) as f64 / nf;
@@ -229,14 +250,20 @@ pub fn fit_all(data: &[f64]) -> StatsResult<Vec<FitResult>> {
         });
     }
 
-    let mut results: Vec<FitResult> = Vec::new();
+    // Pre-allocate KS scratch buffer once; reused across all 10 candidates.
+    let mut ks_buf: Vec<f64> = Vec::with_capacity(data.len());
+    let mut results: Vec<FitResult> = Vec::with_capacity(10);
 
     macro_rules! try_fit {
         ($dist_type:ty, $fit_expr:expr) => {
             if let Ok(dist) = $fit_expr {
                 if let (Ok(aic), Ok(bic)) = (dist.aic(data), dist.bic(data)) {
                     if aic.is_finite() && bic.is_finite() {
-                        let ks = ks_test(data, |x| dist.cdf(x).unwrap_or(0.0));
+                        ks_buf.clear();
+                        ks_buf.extend_from_slice(data);
+                        let ks = ks_test_with_scratch(&mut ks_buf, |x| {
+                            dist.cdf(x).unwrap_or(0.0)
+                        });
                         results.push(FitResult {
                             name: dist.name().to_string(),
                             aic,
@@ -318,8 +345,9 @@ pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<Skipped
         });
     }
 
-    let mut results: Vec<FitResult> = Vec::new();
-    let mut skipped: Vec<SkippedFit> = Vec::new();
+    let mut ks_buf: Vec<f64> = Vec::with_capacity(data.len());
+    let mut results: Vec<FitResult> = Vec::with_capacity(10);
+    let mut skipped: Vec<SkippedFit> = Vec::with_capacity(10);
 
     macro_rules! try_fit_v {
         ($name:literal, $fit_expr:expr) => {
@@ -330,7 +358,11 @@ pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<Skipped
                 }),
                 Ok(dist) => match (dist.aic(data), dist.bic(data)) {
                     (Ok(aic), Ok(bic)) if aic.is_finite() && bic.is_finite() => {
-                        let ks = ks_test(data, |x| dist.cdf(x).unwrap_or(0.0));
+                        ks_buf.clear();
+                        ks_buf.extend_from_slice(data);
+                        let ks = ks_test_with_scratch(&mut ks_buf, |x| {
+                            dist.cdf(x).unwrap_or(0.0)
+                        });
                         results.push(FitResult {
                             name: dist.name().to_string(),
                             aic,
@@ -384,9 +416,11 @@ pub fn fit_all_discrete_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Ve
         });
     }
 
-    let int_data: Vec<u64> = data.iter().map(|&x| x.round() as u64).collect();
-    let mut results: Vec<FitResult> = Vec::new();
-    let mut skipped: Vec<SkippedFit> = Vec::new();
+    let mut int_data: Vec<u64> = Vec::with_capacity(data.len());
+    int_data.extend(data.iter().map(|&x| x.round() as u64));
+    let mut ks_buf: Vec<f64> = Vec::with_capacity(data.len());
+    let mut results: Vec<FitResult> = Vec::with_capacity(4);
+    let mut skipped: Vec<SkippedFit> = Vec::with_capacity(4);
 
     macro_rules! try_fit_disc_v {
         ($name:literal, $fit_expr:expr) => {
@@ -397,7 +431,11 @@ pub fn fit_all_discrete_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Ve
                 }),
                 Ok(dist) => match (dist.aic(&int_data), dist.bic(&int_data)) {
                     (Ok(aic), Ok(bic)) if aic.is_finite() && bic.is_finite() => {
-                        let ks = ks_test_discrete(data, |k| dist.cdf(k).unwrap_or(0.0));
+                        ks_buf.clear();
+                        ks_buf.extend_from_slice(data);
+                        let ks = ks_test_discrete_with_scratch(&mut ks_buf, |k| {
+                            dist.cdf(k).unwrap_or(0.0)
+                        });
                         results.push(FitResult {
                             name: dist.name().to_string(),
                             aic,
@@ -446,17 +484,22 @@ pub fn fit_all_discrete(data: &[f64]) -> StatsResult<Vec<FitResult>> {
         });
     }
 
-    // Convert to u64 for discrete distributions
-    let int_data: Vec<u64> = data.iter().map(|&x| x.round() as u64).collect();
-
-    let mut results: Vec<FitResult> = Vec::new();
+    // Pre-allocate scratch buffers; reused across all 4 candidates.
+    let mut int_data: Vec<u64> = Vec::with_capacity(data.len());
+    int_data.extend(data.iter().map(|&x| x.round() as u64));
+    let mut ks_buf: Vec<f64> = Vec::with_capacity(data.len());
+    let mut results: Vec<FitResult> = Vec::with_capacity(4);
 
     macro_rules! try_fit_disc {
         ($fit_expr:expr) => {
             if let Ok(dist) = $fit_expr {
                 if let (Ok(aic), Ok(bic)) = (dist.aic(&int_data), dist.bic(&int_data)) {
                     if aic.is_finite() && bic.is_finite() {
-                        let ks = ks_test_discrete(data, |k| dist.cdf(k).unwrap_or(0.0));
+                        ks_buf.clear();
+                        ks_buf.extend_from_slice(data);
+                        let ks = ks_test_discrete_with_scratch(&mut ks_buf, |k| {
+                            dist.cdf(k).unwrap_or(0.0)
+                        });
                         results.push(FitResult {
                             name: dist.name().to_string(),
                             aic,

--- a/src/distributions/fitting.rs
+++ b/src/distributions/fitting.rs
@@ -169,10 +169,7 @@ pub fn ks_test_discrete(data: &[f64], cdf: impl Fn(u64) -> f64) -> KsResult {
 }
 
 /// Zero-allocation variant of [`ks_test_discrete`].
-pub fn ks_test_discrete_with_scratch(
-    scratch: &mut [f64],
-    cdf: impl Fn(u64) -> f64,
-) -> KsResult {
+pub fn ks_test_discrete_with_scratch(scratch: &mut [f64], cdf: impl Fn(u64) -> f64) -> KsResult {
     let n = scratch.len();
     if n == 0 {
         return KsResult {
@@ -261,9 +258,7 @@ pub fn fit_all(data: &[f64]) -> StatsResult<Vec<FitResult>> {
                     if aic.is_finite() && bic.is_finite() {
                         ks_buf.clear();
                         ks_buf.extend_from_slice(data);
-                        let ks = ks_test_with_scratch(&mut ks_buf, |x| {
-                            dist.cdf(x).unwrap_or(0.0)
-                        });
+                        let ks = ks_test_with_scratch(&mut ks_buf, |x| dist.cdf(x).unwrap_or(0.0));
                         results.push(FitResult {
                             name: dist.name().to_string(),
                             aic,
@@ -360,9 +355,7 @@ pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<Skipped
                     (Ok(aic), Ok(bic)) if aic.is_finite() && bic.is_finite() => {
                         ks_buf.clear();
                         ks_buf.extend_from_slice(data);
-                        let ks = ks_test_with_scratch(&mut ks_buf, |x| {
-                            dist.cdf(x).unwrap_or(0.0)
-                        });
+                        let ks = ks_test_with_scratch(&mut ks_buf, |x| dist.cdf(x).unwrap_or(0.0));
                         results.push(FitResult {
                             name: dist.name().to_string(),
                             aic,

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -78,9 +78,17 @@ impl Gamma {
                 message: "Gamma::fit: all data values must be positive".to_string(),
             });
         }
-        let n = data.len() as f64;
-        let mean = data.iter().sum::<f64>() / n;
-        let log_mean = data.iter().map(|&x| x.ln()).sum::<f64>() / n;
+        // Single-pass: accumulate Σx and Σln(x) in one walk.
+        let mut sum = 0.0_f64;
+        let mut sum_ln = 0.0_f64;
+        let mut count = 0.0_f64;
+        for &x in data {
+            count += 1.0;
+            sum += x;
+            sum_ln += x.ln();
+        }
+        let mean = sum / count;
+        let log_mean = sum_ln / count;
         // s = ln(mean) - mean(ln(x))  (always ≥ 0)
         let s = mean.ln() - log_mean;
         // Choi-Wette approximation for MLE of α

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -97,11 +97,20 @@ impl LogNormal {
                 message: "LogNormal::fit: all data values must be positive".to_string(),
             });
         }
-        let n = data.len() as f64;
-        let log_data: Vec<f64> = data.iter().map(|&x| x.ln()).collect();
-        let mu = log_data.iter().sum::<f64>() / n;
-        let variance = log_data.iter().map(|&y| (y - mu).powi(2)).sum::<f64>() / n;
-        Self::new(mu, variance.sqrt())
+        // Single-pass online estimator on ln(x) — no intermediate Vec.
+        let mut count = 0.0_f64;
+        let mut mean = 0.0_f64;
+        let mut m2 = 0.0_f64;
+        for &x in data {
+            count += 1.0;
+            let y = x.ln();
+            let delta = y - mean;
+            mean += delta / count;
+            let delta2 = y - mean;
+            m2 += delta * delta2;
+        }
+        let variance = m2 / count; // population variance (MLE)
+        Self::new(mean, variance.sqrt())
     }
 }
 

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -265,22 +265,11 @@ where
         return Ok(f64::INFINITY);
     }
 
-    // Use a simple and reliable implementation based on the Rational Approximation
-    // by Peter J. Acklam
+    // Acklam's rational approximation for the inverse standard normal CDF
+    // (https://web.archive.org/web/20151030215612/http://home.online.no/~pjacklam/notes/invnorm/),
+    // accurate to ~1.15 × 10⁻⁹ over the entire support.
 
-    // Convert to standard normal calculation
-    let q = if p_64 <= 0.5 { p_64 } else { 1.0 - p_64 };
-
-    // Avoid numerical issues at boundaries
-    if q <= 0.0 {
-        return if p_64 <= 0.5 {
-            Ok(f64::NEG_INFINITY)
-        } else {
-            Ok(f64::INFINITY)
-        };
-    }
-
-    // Coefficients for central region (small |z|)
+    // Coefficients — central region (|p − 0.5| ≤ 0.47575)
     let a = [
         -3.969_683_028_665_376e1,
         2.209_460_984_245_205e2,
@@ -289,7 +278,6 @@ where
         -3.066_479_806_614_716e1,
         2.506_628_277_459_239,
     ];
-
     let b = [
         -5.447_609_879_822_406e1,
         1.615_858_368_580_409e2,
@@ -298,54 +286,47 @@ where
         -1.328_068_155_288_572e1,
         1.0,
     ];
+    // Coefficients — tail region
+    let c = [
+        -7.784_894_002_430_293e-3,
+        -3.223_964_580_411_365e-1,
+        -2.400_758_277_161_838,
+        -2.549_732_539_343_734,
+        4.374_664_141_464_968,
+        2.938_163_982_698_783,
+    ];
+    let d = [
+        7.784_695_709_041_462e-3,
+        3.224_671_290_700_398e-1,
+        2.445_134_137_142_996,
+        3.754_408_661_907_416,
+    ];
 
-    // Compute rational approximation
-    let r = q - 0.5;
+    const P_LOW: f64 = 0.02425;
+    const P_HIGH: f64 = 1.0 - P_LOW;
 
-    let z = if q > 0.02425 && q < 0.97575 {
-        // Central region
-        let r2 = r * r;
-        let num = ((((a[0] * r2 + a[1]) * r2 + a[2]) * r2 + a[3]) * r2 + a[4]) * r2 + a[5];
-        let den = ((((b[0] * r2 + b[1]) * r2 + b[2]) * r2 + b[3]) * r2 + b[4]) * r2 + b[5];
-        r * num / den
+    let z = if p_64 < P_LOW {
+        // Lower tail
+        let q = (-2.0 * p_64.ln()).sqrt();
+        let num = ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5];
+        let den = (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0;
+        num / den
+    } else if p_64 > P_HIGH {
+        // Upper tail
+        let q = (-2.0 * (1.0 - p_64).ln()).sqrt();
+        let num = ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5];
+        let den = (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0;
+        -num / den
     } else {
-        // Tail region
-        let s = if r < 0.0 { q } else { 1.0 - q };
-        let t = (-2.0 * s.ln()).sqrt();
-
-        // Rational approximation for tail
-        let c = [
-            -7.784_894_002_430_293e-3,
-            -3.223_964_580_411_365e-1,
-            -2.400_758_277_161_838,
-            -2.549_732_539_343_734,
-            4.374_664_141_464_968,
-            2.938_163_982_698_783,
-        ];
-
-        let d = [
-            7.784_695_709_041_462e-3,
-            3.224_671_290_700_398e-1,
-            2.445_134_137_142_996,
-            3.754_408_661_907_416,
-            1.0,
-        ];
-
-        let num = ((((c[0] * t + c[1]) * t + c[2]) * t + c[3]) * t + c[4]) * t + c[5];
-        let den = (((d[0] * t + d[1]) * t + d[2]) * t + d[3]) * t + d[4];
-        if r < 0.0 {
-            -t - num / den
-        } else {
-            t - num / den
-        }
+        // Central region
+        let q = p_64 - 0.5;
+        let r = q * q;
+        let num = ((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5];
+        let den = ((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + b[5];
+        q * num / den
     };
 
-    // If p > 0.5, we need to flip the sign of z
-    let final_z = if p_64 > 0.5 { -z } else { z };
-
-    let result = mean + std_dev * final_z;
-    // Convert from standard normal to the specified distribution
-    Ok(result)
+    Ok(mean + std_dev * z)
 }
 
 // ── Typed struct + Distribution impl ──────────────────────────────────────────

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -366,16 +366,24 @@ impl Normal {
 
     /// Maximum-likelihood estimate from data.
     ///
-    /// MLE: μ = mean(data), σ = population std-dev.
+    /// MLE: μ = mean(data), σ = population std-dev. Single-pass online
+    /// (Welford) — never walks `data` twice and never allocates.
     pub fn fit(data: &[f64]) -> StatsResult<Self> {
         if data.is_empty() {
             return Err(StatsError::InvalidInput {
                 message: "Normal::fit: data must not be empty".to_string(),
             });
         }
-        let n = data.len() as f64;
-        let mean = data.iter().sum::<f64>() / n;
-        let variance = data.iter().map(|&x| (x - mean).powi(2)).sum::<f64>() / n;
+        let mut count = 0.0_f64;
+        let mut mean = 0.0_f64;
+        let mut m2 = 0.0_f64;
+        for &x in data {
+            count += 1.0;
+            let delta = x - mean;
+            mean += delta / count;
+            m2 += delta * (x - mean);
+        }
+        let variance = m2 / count; // population (MLE)
         Self::new(mean, variance.sqrt())
     }
 }

--- a/src/distributions/weibull.rs
+++ b/src/distributions/weibull.rs
@@ -88,17 +88,30 @@ impl Weibull {
                 message: "Weibull::fit: all data values must be positive".to_string(),
             });
         }
-        let n = data.len() as f64;
-        let mean = data.iter().sum::<f64>() / n;
-        let variance = data.iter().map(|&x| (x - mean).powi(2)).sum::<f64>() / n;
+        // Single-pass online mean+variance (Welford) on data.
+        let mut count = 0.0_f64;
+        let mut mean = 0.0_f64;
+        let mut m2 = 0.0_f64;
+        for &x in data {
+            count += 1.0;
+            let delta = x - mean;
+            mean += delta / count;
+            m2 += delta * (x - mean);
+        }
+        let variance = m2 / count;
         let cv = variance.sqrt() / mean; // coefficient of variation
 
         // Teimouri & Gupta (2013) approximation: k ≈ cv^{-1.086}
         let k = cv.powf(-1.086).max(0.01);
 
-        // Closed-form scale estimate: λ = (Σxᵢᵏ / n)^(1/k)
-        let sum_xk: f64 = data.iter().map(|&x| x.powf(k)).sum::<f64>();
-        let lambda = (sum_xk / n).powf(1.0 / k);
+        // Closed-form scale estimate: λ = (Σxᵢᵏ / n)^(1/k).
+        // This second pass over data still costs O(n) work but is needed —
+        // it depends on `k` which depends on the mean/variance just computed.
+        let mut sum_xk = 0.0_f64;
+        for &x in data {
+            sum_xk += x.powf(k);
+        }
+        let lambda = (sum_xk / count).powf(1.0 / k);
 
         Self::new(k, lambda)
     }

--- a/src/hypothesis_tests/anova.rs
+++ b/src/hypothesis_tests/anova.rs
@@ -25,6 +25,7 @@
 //!   under the null hypothesis that all group means are equal.
 
 use crate::error::{StatsError, StatsResult};
+use crate::utils::special_functions::regularized_incomplete_beta as canonical_inc_beta;
 use num_traits::ToPrimitive;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -186,122 +187,23 @@ where
     })
 }
 
-// Helper function to calculate the CDF of the F-distribution
-// Uses a more accurate implementation of the regularized incomplete beta function
+/// CDF of the F-distribution at `f` with `df1` numerator / `df2` denominator dofs.
+///
+/// Uses the canonical regularised incomplete beta from
+/// [`crate::utils::special_functions`]:
+///   F(f; df1, df2) = I_x(df1/2, df2/2)  with  x = df1·f / (df2 + df1·f).
 fn f_distribution_cdf(f: f64, df1: u32, df2: u32) -> f64 {
-    // F(f; df1, df2) = I_{df2 / (df2 + df1 * f)}(df2/2, df1/2)
-    // For F < 1, we can use the relationship:
-    // F(f; df1, df2) = 1 - F(1/f; df2, df1)
-
     if f <= 0.0 {
         return 0.0;
     }
-
-    // For F < 1, we use the complementary calculation
-    if f < 1.0 {
-        // Use the relationship: F(f; df1, df2) = 1 - F(1/f; df2, df1)
-        return 1.0 - f_distribution_cdf(1.0 / f, df2, df1);
-    }
-
-    // Ensure denominator is not zero to avoid division by zero
-    // df2 + df1 * f should never be zero for valid F-statistics, but check anyway
-    let denominator = df2 as f64 + df1 as f64 * f;
-    if denominator.abs() < 1e-15 {
-        // This should not happen for valid F-statistics, but handle edge case
-        // Return 0.0 or handle appropriately
-        return 0.0;
-    }
-
-    let x = df2 as f64 / denominator;
-    let a = df2 as f64 / 2.0;
-    let b = df1 as f64 / 2.0;
-
-    // Use a more accurate implementation of the regularized incomplete beta function
-    let cdf = regularized_incomplete_beta(x, a, b);
-    // Clamp to [0, 1] to handle numerical precision issues
-    cdf.clamp(0.0, 1.0)
-}
-
-// Improved implementation of the regularized incomplete beta function
-fn regularized_incomplete_beta(x: f64, a: f64, b: f64) -> f64 {
-    if x <= 0.0 {
-        return 0.0;
-    }
-    if x >= 1.0 {
+    let df1f = df1 as f64;
+    let df2f = df2 as f64;
+    let denom = df2f + df1f * f;
+    if denom.abs() < 1e-15 {
         return 1.0;
     }
-
-    // For small values of a and b, use a continued fraction approach
-    // For values where x is closer to 0, use a power series
-
-    // Use a power series expansion for the incomplete beta function
-    let mut term = 1.0;
-    let mut sum = 0.0;
-    let max_iterations = 200;
-
-    // Calculate beta function normalization
-    let ln_beta = ln_gamma(a) + ln_gamma(b) - ln_gamma(a + b);
-
-    // Handle the case where a + b = 1.0 to avoid division by zero when i = 0
-    // When a + b = 1.0 and i = 0, denominator = a + b + 0 - 1.0 = 0.0
-    // We need to ensure denominator != 0 before dividing
-
-    for i in 0..max_iterations {
-        if i > 0 {
-            term *= (a + i as f64 - 1.0) * x / i as f64;
-        }
-        let denominator = a + b + i as f64 - 1.0;
-        // Avoid division by zero: ensure denominator != 0 before dividing
-        // This handles the case when a + b = 1.0 and i = 0
-        if denominator.abs() > 1e-15 {
-            sum += term / denominator;
-        }
-        // If denominator is zero (a+b=1.0 and i=0), skip this iteration
-        // For the special case a+b=1.0, the i=0 term contributes 1.0/(a+b) = 1.0
-        // But since we're skipping it, we'll rely on the remaining terms for convergence
-        if term.abs() < 1e-15 {
-            break;
-        }
-    }
-
-    // If we skipped the i=0 term due to a+b=1.0, we need to compensate
-    // For a+b=1.0, the missing term is approximately 1.0/(a+b) = 1.0
-    // But this is already handled by the fact that term starts at 1.0
-    // and we're computing the series correctly
-
-    (x.powf(a) * (1.0 - x).powf(b) / (-ln_beta).exp()) * sum
-}
-
-// Approximation of the natural logarithm of the gamma function
-fn ln_gamma(x: f64) -> f64 {
-    // Lanczos approximation for ln(Gamma(x))
-    if x <= 0.0 {
-        return f64::INFINITY; // Not valid for non-positive numbers
-    }
-
-    // Coefficients for the Lanczos approximation
-    let p = [
-        676.5203681218851,
-        -1259.1392167224028,
-        771.323_428_777_653_1,
-        -176.615_029_162_140_6,
-        12.507343278686905,
-        -0.13857109526572012,
-        9.984_369_578_019_572e-6,
-        1.5056327351493116e-7,
-    ];
-
-    let mut result = 0.999_999_999_999_809_9;
-    let z: f64 = x - 1.0;
-
-    for (i, &val) in p.iter().enumerate() {
-        result += val / (z + (i as f64) + 1.0);
-    }
-
-    let t = z + p.len() as f64 - 0.5;
-    // Use precomputed constant instead of computing ln(2π) every call
-    use crate::utils::constants::LN_2PI;
-    LN_2PI / 2.0 + (t + 0.5) * t.ln() - t + result.ln()
+    let x = (df1f * f) / denom;
+    canonical_inc_beta(0.5 * df1f, 0.5 * df2f, x).clamp(0.0, 1.0)
 }
 
 #[cfg(test)]

--- a/src/hypothesis_tests/anova.rs
+++ b/src/hypothesis_tests/anova.rs
@@ -27,8 +27,6 @@
 use crate::error::{StatsError, StatsResult};
 use crate::utils::special_functions::regularized_incomplete_beta as canonical_inc_beta;
 use num_traits::ToPrimitive;
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
 use std::fmt::Debug;
 
 /// Result of a one-way ANOVA test
@@ -97,73 +95,63 @@ where
         ));
     }
 
-    // Convert all data to f64 and check that each group has at least 2 observations
-    let mut groups: Vec<Vec<f64>> = Vec::with_capacity(groups_data.len());
+    // Single-pass Welford per group: never materialises Vec<Vec<f64>>,
+    // never walks any group twice. We keep only `(count, mean, m2)` per
+    // group — three f64s — instead of allocating a converted copy of every
+    // observation. ss_within = Σ m2 falls out for free.
+    let n_groups = groups_data.len();
+    let mut counts: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut means: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut m2s: Vec<f64> = Vec::with_capacity(n_groups);
+
     for (group_idx, group) in groups_data.iter().enumerate() {
-        let mut converted_group = Vec::with_capacity(group.len());
+        let mut count = 0.0_f64;
+        let mut mean = 0.0_f64;
+        let mut m2 = 0.0_f64;
         for (value_idx, &value) in group.iter().enumerate() {
-            let f64_value = value.to_f64().ok_or_else(|| {
+            let v = value.to_f64().ok_or_else(|| {
                 StatsError::conversion_error(format!(
                     "Failed to convert value at group {}, index {} to f64",
                     group_idx, value_idx
                 ))
             })?;
-            converted_group.push(f64_value);
+            count += 1.0;
+            let delta = v - mean;
+            mean += delta / count;
+            m2 += delta * (v - mean);
         }
-        if converted_group.len() < 2 {
+        if count < 2.0 {
             return Err(StatsError::invalid_input(format!(
                 "Each group must have at least 2 observations (group {} has {})",
-                group_idx,
-                converted_group.len()
+                group_idx, count as usize
             )));
         }
-        groups.push(converted_group);
+        counts.push(count);
+        means.push(mean);
+        m2s.push(m2);
     }
 
-    // Calculate total number of observations
-    let n_total: usize = groups.iter().map(|group| group.len()).sum();
-
-    // Calculate the grand mean (mean of all observations) — zero-allocation iterator chain
-    let grand_mean = groups
+    let n_total_f = counts.iter().sum::<f64>();
+    let n_total = n_total_f as usize;
+    let grand_mean = counts
         .iter()
-        .flat_map(|group| group.iter().copied())
+        .zip(means.iter())
+        .map(|(&n, &m)| n * m)
         .sum::<f64>()
-        / (n_total as f64);
+        / n_total_f;
 
-    // Calculate group means (parallel when feature enabled)
-    #[cfg(feature = "parallel")]
-    let group_means: Vec<f64> = groups
-        .par_iter()
-        .map(|group| group.iter().sum::<f64>() / (group.len() as f64))
-        .collect();
-    #[cfg(not(feature = "parallel"))]
-    let group_means: Vec<f64> = groups
+    let ss_between: f64 = counts
         .iter()
-        .map(|group| group.iter().sum::<f64>() / (group.len() as f64))
-        .collect();
-
-    // Calculate sum of squares between groups (SSB)
-    let ss_between: f64 = groups
-        .iter()
-        .zip(group_means.iter())
-        .map(|(group, &group_mean)| (group_mean - grand_mean).powi(2) * (group.len() as f64))
-        .sum();
-
-    // Calculate sum of squares within groups (SSW)
-    let ss_within: f64 = groups
-        .iter()
-        .zip(group_means.iter())
-        .map(|(group, &group_mean)| {
-            group
-                .iter()
-                .map(|&value| (value - group_mean).powi(2))
-                .sum::<f64>()
+        .zip(means.iter())
+        .map(|(&n, &m)| {
+            let d = m - grand_mean;
+            d * d * n
         })
         .sum();
+    let ss_within: f64 = m2s.iter().sum();
 
-    // Calculate degrees of freedom
-    let df_between = groups.len() - 1;
-    let df_within = n_total - groups.len();
+    let df_between = n_groups - 1;
+    let df_within = n_total - n_groups;
 
     // Calculate mean squares
     let ms_between = ss_between / (df_between as f64);

--- a/src/hypothesis_tests/chi_square_test.rs
+++ b/src/hypothesis_tests/chi_square_test.rs
@@ -18,10 +18,24 @@
 //! The resulting statistic follows a chi-square distribution with degrees of freedom based on the particular test.
 
 use crate::error::{StatsError, StatsResult};
-use crate::prob::erf;
-use crate::utils::constants::SQRT_2;
+use crate::utils::special_functions::regularized_incomplete_gamma;
 use num_traits::ToPrimitive;
 use std::fmt::Debug;
+
+/// Right-tail (survival) probability of the χ² distribution at `chi_sq` with `df` dofs.
+///
+/// Uses the canonical regularised incomplete gamma:
+///   P(χ²_df ≥ x) = 1 − P(df/2, x/2)
+#[inline]
+fn chi_square_sf(chi_sq: f64, df: usize) -> f64 {
+    if df == 0 {
+        return 1.0;
+    }
+    if chi_sq <= 0.0 {
+        return 1.0;
+    }
+    (1.0 - regularized_incomplete_gamma(df as f64 / 2.0, chi_sq / 2.0)).clamp(0.0, 1.0)
+}
 
 /// Performs a chi-square goodness of fit test, which determines if a sample matches a population distribution.
 ///
@@ -112,21 +126,9 @@ where
         chi_square += (diff * diff) / exp;
     }
 
-    // Calculate p-value using the chi-square distribution
-    // This is an approximation using Wilson-Hilferty transformation
-    let p_value = if degrees_of_freedom > 0 {
-        let mut z = (chi_square / degrees_of_freedom as f64).powf(1.0 / 3.0)
-            - (1.0 - 2.0 / (9.0 * degrees_of_freedom as f64));
-        z /= (2.0 / (9.0 * degrees_of_freedom as f64)).sqrt();
+    let p_value = chi_square_sf(chi_square, degrees_of_freedom);
 
-        // Standard normal CDF approximation
-        0.5 * (1.0 + erf(z / SQRT_2)?)
-    } else {
-        1.0 // If df = 0, return p-value of 1.0
-    };
-
-    // Return the chi-square statistic, degrees of freedom, and p-value
-    Ok((chi_square, degrees_of_freedom, 1.0 - p_value))
+    Ok((chi_square, degrees_of_freedom, p_value))
 }
 
 /// Performs a chi-square test of independence, which determines if there is a significant relationship
@@ -258,21 +260,9 @@ where
     // Calculate degrees of freedom
     let degrees_of_freedom = (row_count - 1) * (col_count - 1);
 
-    // Calculate p-value using the chi-square distribution
-    // This is an approximation using Wilson-Hilferty transformation
-    let p_value = if degrees_of_freedom > 0 {
-        let mut z = (chi_square / degrees_of_freedom as f64).powf(1.0 / 3.0)
-            - (1.0 - 2.0 / (9.0 * degrees_of_freedom as f64));
-        z /= (2.0 / (9.0 * degrees_of_freedom as f64)).sqrt();
+    let p_value = chi_square_sf(chi_square, degrees_of_freedom);
 
-        // Standard normal CDF approximation
-        0.5 * (1.0 + erf(z / SQRT_2)?)
-    } else {
-        1.0 // If df = 0, return p-value of 1.0
-    };
-
-    // Return the chi-square statistic, degrees of freedom, and p-value
-    Ok((chi_square, degrees_of_freedom, 1.0 - p_value))
+    Ok((chi_square, degrees_of_freedom, p_value))
 }
 
 #[cfg(test)]
@@ -442,11 +432,9 @@ mod tests {
             statistic, 0.0,
             "Chi-square statistic should be 0 when observed equals expected"
         );
-        // When df == 0, p-value should be 1.0 (as per the code)
-        assert_eq!(
-            p_value, 0.0,
-            "p-value should be 0.0 when df == 0 (1.0 - 1.0)"
-        );
+        // df == 0 is the trivial single-category case: no evidence to
+        // reject the null, so the survival function returns p = 1.0.
+        assert_eq!(p_value, 1.0, "p-value should be 1.0 when df == 0");
     }
 
     #[test]

--- a/src/hypothesis_tests/t_test.rs
+++ b/src/hypothesis_tests/t_test.rs
@@ -17,8 +17,7 @@
 //! uncertainty from estimating the standard deviation.
 
 use crate::error::{StatsError, StatsResult};
-use crate::prob::erf;
-use crate::utils::constants::{LN_2PI, SQRT_2};
+use crate::utils::special_functions::regularized_incomplete_beta;
 use num_traits::ToPrimitive;
 use std::f64;
 use std::fmt::Debug;
@@ -396,170 +395,20 @@ where
     Ok(sum_squared_diff / (n - 1.0))
 }
 
-/// Calculates p-value from t-statistic and degrees of freedom
+/// Calculates the two-tailed p-value from a t-statistic and degrees of freedom.
 ///
-/// # Arguments
-/// * `t_stat` - The absolute value of the t-statistic
-/// * `df` - Degrees of freedom
+/// Uses the canonical regularized incomplete beta from
+/// [`crate::utils::special_functions::regularized_incomplete_beta`].
 ///
-/// # Returns
-/// The two-tailed p-value corresponding to the t-statistic and degrees of freedom
+/// For Student's t with `df` degrees of freedom:
+///   p-value = I_x(df/2, 1/2)  with  x = df / (df + t²)
+///
+/// (See e.g. Abramowitz & Stegun, eq. 26.7.4.)
 #[inline]
 fn calculate_p_value(t_stat: f64, df: f64) -> f64 {
-    // For very large degrees of freedom, t-distribution approaches normal distribution
-    if df > 1000.0 {
-        // Use normal approximation for large df
-        let z = t_stat;
-        return 2.0 * (1.0 - standard_normal_cdf(z));
-    }
-
-    // Use Student's t-distribution CDF approximation
-    // This is an implementation of the algorithm from:
-    // Abramowitz and Stegun: Handbook of Mathematical Functions
-    //
-    // The incomplete beta function I_x(a, b) where x = df/(df + t^2) gives us
-    // the cumulative probability P(T ≤ |t|) for the t-distribution.
-    // For a two-tailed test: p-value = 2 * (1 - P(T ≤ |t|))
-
-    let a = df / (df + t_stat * t_stat);
-    let ix = incomplete_beta(0.5 * df, 0.5, a);
-
-    // Two-tailed p-value: clamp to [0.0, 1.0] to handle numerical precision issues
-    (2.0 * (1.0 - ix)).clamp(0.0, 1.0)
-}
-
-/// Standard normal cumulative distribution function
-#[inline]
-fn standard_normal_cdf(x: f64) -> f64 {
-    // Use error function relationship with normal CDF
-    // unwrap is safe here as erf always succeeds for f64 values
-    0.5 * (1.0 + erf(x / SQRT_2).unwrap())
-}
-
-/// Incomplete beta function approximation
-/// Used for calculating the cumulative distribution function of the t-distribution
-#[inline]
-fn incomplete_beta(a: f64, b: f64, x: f64) -> f64 {
-    if x == 0.0 || x == 1.0 {
-        return x;
-    }
-
-    // Use continued fraction approximation for incomplete beta
-    let symmetry_point = x > (a / (a + b));
-
-    // Apply symmetry for more accurate computation when x > a/(a+b)
-    let (a_calc, b_calc, x_calc) = if symmetry_point {
-        (b, a, 1.0 - x)
-    } else {
-        (a, b, x)
-    };
-
-    // Constants for the continued fraction method
-    let max_iterations = 200;
-    let epsilon = 1e-10;
-
-    // Continued fraction expansion using modified Lentz's method
-    let front_factor = x_calc.powf(a_calc) * (1.0 - x_calc).powf(b_calc) / beta(a_calc, b_calc);
-
-    let mut h = 1.0;
-    let mut d = 1.0;
-    let mut result = 0.0;
-
-    for m in 1..max_iterations {
-        let m = m as f64;
-        let m2 = 2.0 * m;
-
-        // Even term
-        let numerator = (m * (b_calc - m) * x_calc) / ((a_calc + m2 - 1.0) * (a_calc + m2));
-
-        d = 1.0 + numerator * d;
-        if d.abs() < epsilon {
-            d = epsilon;
-        }
-        d = 1.0 / d;
-
-        h = 1.0 + numerator / h;
-        if h.abs() < epsilon {
-            h = epsilon;
-        }
-
-        result *= h * d;
-
-        // Odd term
-        let numerator = -((a_calc + m) * (a_calc + b_calc + m) * x_calc)
-            / ((a_calc + m2) * (a_calc + m2 + 1.0));
-
-        d = 1.0 + numerator * d;
-        if d.abs() < epsilon {
-            d = epsilon;
-        }
-        d = 1.0 / d;
-
-        h = 1.0 + numerator / h;
-        if h.abs() < epsilon {
-            h = epsilon;
-        }
-
-        let delta = h * d;
-        result *= delta;
-
-        // Check for convergence
-        if (delta - 1.0).abs() < epsilon {
-            break;
-        }
-    }
-
-    // Apply the front factor
-    result *= front_factor;
-
-    // Return appropriate result based on symmetry
-    if symmetry_point { 1.0 - result } else { result }
-}
-
-/// Beta function B(a, b) = Γ(a) * Γ(b) / Γ(a + b)
-/// where Γ is the gamma function
-#[inline]
-fn beta(a: f64, b: f64) -> f64 {
-    // Use Stirling's approximation for gamma function
-    let log_gamma_a = ln_gamma(a);
-    let log_gamma_b = ln_gamma(b);
-    let log_gamma_ab = ln_gamma(a + b);
-
-    (log_gamma_a + log_gamma_b - log_gamma_ab).exp()
-}
-
-/// Natural logarithm of the gamma function
-/// Using Lanczos approximation for the gamma function
-#[inline]
-fn ln_gamma(x: f64) -> f64 {
-    // Lanczos coefficients
-    let p = [
-        676.5203681218851,
-        -1259.1392167224028,
-        771.323_428_777_653_1,
-        -176.615_029_162_140_6,
-        12.507343278686905,
-        -0.13857109526572012,
-        9.984_369_578_019_572e-6,
-        1.5056327351493116e-7,
-    ];
-
-    if x < 0.5 {
-        // Reflection formula: Γ(1-x) = π / (sin(πx) * Γ(x))
-        // ln(Γ(x)) = ln(π) - ln(sin(πx)) - ln(Γ(1-x))
-        crate::utils::constants::PI.ln()
-            - (crate::utils::constants::PI * x).sin().ln()
-            - ln_gamma(1.0 - x)
-    } else {
-        // Standard Lanczos approximation for x ≥ 0.5
-        let mut sum = p[0];
-        for (i, &value) in p.iter().enumerate().skip(1) {
-            sum += value / (x + i as f64);
-        }
-
-        let t = x + 7.5;
-        (x + 0.5) * t.ln() - t + LN_2PI * 0.5 + sum.ln() / x
-    }
+    let t2 = t_stat * t_stat;
+    let x = df / (df + t2);
+    regularized_incomplete_beta(0.5 * df, 0.5, x).clamp(0.0, 1.0)
 }
 
 #[cfg(test)]

--- a/src/hypothesis_tests/t_test.rs
+++ b/src/hypothesis_tests/t_test.rs
@@ -263,15 +263,18 @@ where
         ));
     }
 
-    // Single-pass conversion + Welford for all three streams (data1, data2, differences).
-    // Zero heap allocation: O(1) memory instead of O(n) for the differences Vec.
+    // Single-pass online statistics for all three streams (data1, data2,
+    // differences). Each stream tracks its own running mean explicitly —
+    // the previous (buggy) version used `running_sum / count` as the
+    // pre-update mean, which lags by one step and yields wrong std_devs.
     let n = data1.len() as f64;
-    let mut sum1 = 0.0_f64;
-    let mut sum2 = 0.0_f64;
-    let mut m2_1 = 0.0_f64; // Welford accumulator for data1
-    let mut m2_2 = 0.0_f64; // Welford accumulator for data2
-    let mut diff_mean = 0.0_f64; // Welford mean for differences
-    let mut diff_m2 = 0.0_f64; // Welford M2 for differences
+    let mut count = 0.0_f64;
+    let mut mean1 = 0.0_f64;
+    let mut mean2 = 0.0_f64;
+    let mut m2_1 = 0.0_f64;
+    let mut m2_2 = 0.0_f64;
+    let mut diff_mean = 0.0_f64;
+    let mut diff_m2 = 0.0_f64;
 
     for i in 0..data1.len() {
         let val1 = data1[i].to_f64().ok_or_else(|| {
@@ -287,30 +290,22 @@ where
             ))
         })?;
 
-        let count = (i + 1) as f64;
+        count += 1.0;
 
-        // Welford online variance for data1
-        let delta1 = val1 - sum1 / count.max(1.0);
-        sum1 += val1;
-        let delta1_post = val1 - sum1 / count;
-        m2_1 += delta1 * delta1_post;
+        let delta1 = val1 - mean1;
+        mean1 += delta1 / count;
+        m2_1 += delta1 * (val1 - mean1);
 
-        // Welford online variance for data2
-        let delta2 = val2 - sum2 / count.max(1.0);
-        sum2 += val2;
-        let delta2_post = val2 - sum2 / count;
-        m2_2 += delta2 * delta2_post;
+        let delta2 = val2 - mean2;
+        mean2 += delta2 / count;
+        m2_2 += delta2 * (val2 - mean2);
 
-        // Welford online mean + variance for differences (no Vec needed)
         let d = val1 - val2;
         let delta_d = d - diff_mean;
         diff_mean += delta_d / count;
-        let delta_d2 = d - diff_mean;
-        diff_m2 += delta_d * delta_d2;
+        diff_m2 += delta_d * (d - diff_mean);
     }
 
-    let mean1 = sum1 / n;
-    let mean2 = sum2 / n;
     let std_dev1 = (m2_1 / (n - 1.0)).sqrt();
     let std_dev2 = (m2_2 / (n - 1.0)).sqrt();
 

--- a/src/prob/erf.rs
+++ b/src/prob/erf.rs
@@ -15,10 +15,14 @@
 //! - erf(-∞) = -1
 //!
 //! ## Implementation Details
-//! Uses Abramowitz and Stegun formula 7.1.26 for approximation
-//! with maximum error of 1.5 × 10⁻⁷
+//! Computed via the regularised lower incomplete gamma function:
+//!   erf(x) = sign(x) · P(1/2, x²)
+//! This delegates to [`crate::utils::special_functions::regularized_incomplete_gamma`]
+//! and is accurate to ~1e-12 across the real line — substantially better
+//! than the previous Abramowitz-Stegun 7.1.26 approximation (max error 1.5e-7).
 
 use crate::error::{StatsError, StatsResult};
+use crate::utils::special_functions::regularized_incomplete_gamma;
 use num_traits::ToPrimitive;
 
 /// Calculate the error function (erf) of a value
@@ -39,10 +43,10 @@ use num_traits::ToPrimitive;
 /// // Calculate erf(1.0)
 /// let x: f64 = 1.0;
 /// let result = erf(x).unwrap();
-/// assert!((result - 0.8427006897475899).abs() < 1e-8);
+/// assert!((result - 0.842_700_792_949_714_9).abs() < 1e-12);
 ///
 /// // Verify symmetry property
-/// assert!((erf(x).unwrap() + erf(-x).unwrap()).abs() < 1e-8);
+/// assert!((erf(x).unwrap() + erf(-x).unwrap()).abs() < 1e-12);
 /// ```
 #[inline]
 pub fn erf<T>(x: T) -> StatsResult<f64>
@@ -52,27 +56,18 @@ where
     let x = x.to_f64().ok_or_else(|| StatsError::ConversionError {
         message: "prob::erf: Failed to convert x to f64".to_string(),
     })?;
-    // Special case: return exactly 0.0 when x is 0.0
     if x == 0.0 {
         return Ok(0.0);
     }
-
-    let sign = if x < 0.0 { -1.0 } else { 1.0 };
-    let x = x.abs();
-
-    // Constants for the approximation
-    let a1 = 0.254829592;
-    let a2 = -0.284496736;
-    let a3 = 1.421413741;
-    let a4 = -1.453152027;
-    let a5 = 1.061405429;
-    let p = 0.3275911;
-
-    // Abramowitz and Stegun formula 7.1.26
-    let t = 1.0 / (1.0 + p * x);
-    let y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * (-x * x).exp();
-
-    Ok(sign * y)
+    if x.is_nan() {
+        return Ok(f64::NAN);
+    }
+    if x.is_infinite() {
+        return Ok(if x > 0.0 { 1.0 } else { -1.0 });
+    }
+    let sign = x.signum();
+    // erf(x) = sign(x) · P(1/2, x²) via the canonical incomplete gamma.
+    Ok(sign * regularized_incomplete_gamma(0.5, x * x))
 }
 
 #[cfg(test)]

--- a/src/prob/erfc.rs
+++ b/src/prob/erfc.rs
@@ -37,13 +37,13 @@ use num_traits::ToPrimitive;
 /// ```
 /// use rs_stats::prob::erfc;
 ///
-/// // Calculate erfc(1.0)
+/// // Calculate erfc(1.0) = 1 − erf(1.0)
 /// let result = erfc(1.0).unwrap();
-/// assert!((result - 0.15729931025241006).abs() < 1e-8);
+/// assert!((result - 0.157_299_207_050_285_1).abs() < 1e-12);
 ///
 /// // Verify relationship to normal distribution
 /// let p = 0.5 * erfc(1.0 / 2.0f64.sqrt()).unwrap();
-/// assert!((p - 0.15865526383236372).abs() < 1e-8); // P(X > 1) for N(0,1)
+/// assert!((p - 0.158_655_253_931_457_1).abs() < 1e-10); // P(X > 1) for N(0,1)
 /// ```
 #[inline]
 pub fn erfc<T>(x: T) -> StatsResult<f64>

--- a/src/prob/welford.rs
+++ b/src/prob/welford.rs
@@ -329,13 +329,37 @@ impl WelfordVector {
     /// # Errors
     /// Returns [`StatsError::EmptyData`] if `count() < 2`.
     pub fn variance(&self) -> StatsResult<Vec<f64>> {
+        let mut out = vec![0.0; self.m2.len()];
+        self.variance_into(&mut out)?;
+        Ok(out)
+    }
+
+    /// Zero-allocation variant of [`variance`](Self::variance).
+    ///
+    /// Writes the per-axis sample variance into `out` (length must equal `dim()`).
+    /// Hoist `out` out of any per-call hot loop.
+    ///
+    /// # Errors
+    /// * [`StatsError::EmptyData`] if `count() < 2`.
+    /// * [`StatsError::InvalidInput`] if `out.len() != dim()`.
+    pub fn variance_into(&self, out: &mut [f64]) -> StatsResult<()> {
         if self.n < 2 {
             return Err(StatsError::empty_data(
                 "WelfordVector::variance: need at least 2 observations",
             ));
         }
+        if out.len() != self.m2.len() {
+            return Err(StatsError::invalid_input(format!(
+                "WelfordVector::variance_into: out len {} != dim {}",
+                out.len(),
+                self.m2.len()
+            )));
+        }
         let denom = (self.n - 1) as f64;
-        Ok(self.m2.iter().map(|m| m / denom).collect())
+        for (o, m) in out.iter_mut().zip(self.m2.iter()) {
+            *o = m / denom;
+        }
+        Ok(())
     }
 
     /// Per-axis sample standard deviation.
@@ -343,7 +367,21 @@ impl WelfordVector {
     /// # Errors
     /// Returns [`StatsError::EmptyData`] if `count() < 2`.
     pub fn std_dev(&self) -> StatsResult<Vec<f64>> {
-        Ok(self.variance()?.into_iter().map(f64::sqrt).collect())
+        let mut out = vec![0.0; self.m2.len()];
+        self.std_dev_into(&mut out)?;
+        Ok(out)
+    }
+
+    /// Zero-allocation variant of [`std_dev`](Self::std_dev).
+    ///
+    /// # Errors
+    /// Same as [`variance_into`](Self::variance_into).
+    pub fn std_dev_into(&self, out: &mut [f64]) -> StatsResult<()> {
+        self.variance_into(out)?;
+        for o in out.iter_mut() {
+            *o = o.sqrt();
+        }
+        Ok(())
     }
 }
 

--- a/src/utils/linalg.rs
+++ b/src/utils/linalg.rs
@@ -61,56 +61,7 @@ pub fn invert(matrix: &[f64], dim: usize, eps: f64) -> StatsResult<Vec<f64>> {
         }
         aug[r * w + dim + r] = 1.0;
     }
-
-    // Forward elimination with partial pivoting.
-    for col in 0..dim {
-        // Find pivot row.
-        let mut pivot_row = col;
-        let mut pivot_val = aug[col * w + col].abs();
-        for r in (col + 1)..dim {
-            let v = aug[r * w + col].abs();
-            if v > pivot_val {
-                pivot_val = v;
-                pivot_row = r;
-            }
-        }
-        if pivot_val < eps {
-            return Err(StatsError::numerical_error(format!(
-                "linalg::invert: matrix is singular (pivot {} < eps {})",
-                pivot_val, eps
-            )));
-        }
-        if pivot_row != col {
-            for c in 0..w {
-                aug.swap(col * w + c, pivot_row * w + c);
-            }
-        }
-        let inv_pivot = 1.0 / aug[col * w + col];
-        for c in 0..w {
-            aug[col * w + c] *= inv_pivot;
-        }
-        for r in 0..dim {
-            if r == col {
-                continue;
-            }
-            let factor = aug[r * w + col];
-            if factor == 0.0 {
-                continue;
-            }
-            for c in 0..w {
-                aug[r * w + c] -= factor * aug[col * w + c];
-            }
-        }
-    }
-
-    // Extract inverse (right half of augmented matrix).
-    let mut inv = vec![0.0; dim * dim];
-    for r in 0..dim {
-        for c in 0..dim {
-            inv[r * dim + c] = aug[r * w + dim + c];
-        }
-    }
-    Ok(inv)
+    invert_augmented(aug, dim, eps)
 }
 
 /// Invert with Tikhonov (ridge) regularization.
@@ -156,11 +107,70 @@ pub fn invert_with_ridge(matrix: &[f64], dim: usize, ridge_factor: f64) -> Stats
         trace += matrix[i * dim + i];
     }
     let lambda = (trace / dim as f64 / ridge_factor.max(1e-9)).max(1e-12);
-    let mut reg = matrix.to_vec();
-    for i in 0..dim {
-        reg[i * dim + i] += lambda;
+
+    // Build the augmented [A + λI | I] matrix in a single pass — saves one
+    // Vec<f64> of length dim² compared with `matrix.to_vec()` + diagonal patch.
+    let w = 2 * dim;
+    let mut aug = vec![0.0; dim * w];
+    for r in 0..dim {
+        for c in 0..dim {
+            aug[r * w + c] = matrix[r * dim + c];
+        }
+        aug[r * w + r] += lambda;
+        aug[r * w + dim + r] = 1.0;
     }
-    invert(&reg, dim, 1e-9)
+    invert_augmented(aug, dim, 1e-9)
+}
+
+/// Gauss-Jordan elimination on a pre-built `[A | I]` augmented matrix of shape
+/// `dim × (2·dim)`. Shared between [`invert`] and [`invert_with_ridge`].
+fn invert_augmented(mut aug: Vec<f64>, dim: usize, eps: f64) -> StatsResult<Vec<f64>> {
+    let w = 2 * dim;
+    for col in 0..dim {
+        let mut pivot_row = col;
+        let mut pivot_val = aug[col * w + col].abs();
+        for r in (col + 1)..dim {
+            let v = aug[r * w + col].abs();
+            if v > pivot_val {
+                pivot_val = v;
+                pivot_row = r;
+            }
+        }
+        if pivot_val < eps {
+            return Err(StatsError::numerical_error(format!(
+                "linalg::invert: matrix is singular (pivot {} < eps {})",
+                pivot_val, eps
+            )));
+        }
+        if pivot_row != col {
+            for c in 0..w {
+                aug.swap(col * w + c, pivot_row * w + c);
+            }
+        }
+        let inv_pivot = 1.0 / aug[col * w + col];
+        for c in 0..w {
+            aug[col * w + c] *= inv_pivot;
+        }
+        for r in 0..dim {
+            if r == col {
+                continue;
+            }
+            let factor = aug[r * w + col];
+            if factor == 0.0 {
+                continue;
+            }
+            for c in 0..w {
+                aug[r * w + c] -= factor * aug[col * w + c];
+            }
+        }
+    }
+    let mut inv = vec![0.0; dim * dim];
+    for r in 0..dim {
+        for c in 0..dim {
+            inv[r * dim + c] = aug[r * w + dim + c];
+        }
+    }
+    Ok(inv)
 }
 
 /// Mahalanobis-style squared distance `(x-μ)ᵀ · M · (x-μ)`.


### PR DESCRIPTION
## Summary

- **New (v2.1.0)**: `prob::welford` (scalar / per-axis / full-covariance Welford with merge + zero-alloc covariance) and `utils::linalg` (`invert`, `invert_with_ridge`, `mahalanobis_sq` + zero-alloc `_into` variant). Plus `WelfordVector::variance_into` / `std_dev_into` for zero-allocation per-axis stats.
- **Numerical bug fixes** found by a local numpy/scipy cross-validation harness (gitignored at \`validation/\`):
  - `t_test::{one_sample, two_sample (Welch), paired}_t_test` returned wrong p-values (often clamped to 1.0) because of a broken in-file `incomplete_beta`. Now delegates to `utils::special_functions::regularized_incomplete_beta`.
  - `anova::one_way_anova` collapsed to p ≈ 0 for moderate F-statistics. Same root cause, same fix.
  - `chi_square::{goodness_of_fit, independence}` used Wilson-Hilferty (~0.3 % error). Now exact via `regularized_incomplete_gamma`.
  - `normal_inverse_cdf` was off by a factor of ~3 in the tails (p ≤ 0.02425 or p ≥ 0.97575). Acklam's rational approximation is now applied as published.
  - `prob::erf` upgraded from Abramowitz-Stegun 7.1.26 (~1.5e-7) to delegate through the canonical incomplete gamma (~1e-12). The library's own normal CDF, hypothesis tests, etc. all benefit.
- **Performance**:
  - `LogNormal::fit` — single-pass online mean+var on `ln(x)` (skips one `Vec<f64>` of size n).
  - `linalg::invert_with_ridge` — builds the augmented matrix in one pass (saves a `Vec<f64>` of length dim²), `invert` and `invert_with_ridge` now share a single kernel.
  - `fit_all` / `fit_all_verbose` / `fit_all_discrete{,_verbose}` reuse a single KS scratch buffer + capacity hints on result Vecs — ~10× fewer allocations on the continuous fit path, ~4× on the discrete one.
- **Code health**: removed ~480 lines of redundant Lanczos / continued-fraction code that was duplicated across `t_test`, `anova`, and `chi_square_test`.
- **License**: relicensed from GPL-3.0 → MIT (consistent with the README badge that was already advertising MIT). `LICENSE` file added.

## Test plan
- [x] `cargo test --lib` — 368 passed
- [x] `cargo test --doc` — 89 passed
- [x] Local numpy/scipy/sklearn cross-validation harness — 35 invariants checked, all green (matches scipy to 1e-9 / 1e-12 on most paths). Lives at `validation/run.sh`, gitignored.
- [ ] CI green on push
- [ ] Spot-check `cargo doc --no-deps` once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)