### PR TITLE
v4.0.0 — correctness, performance, and a complete inference toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## [v4.0.0](https://github.com/Lsh0x/rs-stats/tree/v4.0.0)
+
+The "trust the tails" release: every numeric path is cross-validated
+against scipy/numpy, including extreme-tail regimes, and the whole
+library gets sampling, survival functions, non-parametric tests,
+resampling, exact power analysis and 5 new distributions.
+
+**Breaking changes:**
+
+- `chi_square_goodness_of_fit` / `chi_square_independence` return a named
+  `ChiSquareResult { statistic, degrees_of_freedom, p_value }` instead of
+  a positional `(f64, usize, f64)` tuple.
+- `std_err` now uses the **sample** convention (ddof = 1, matching
+  `scipy.stats.sem`); the previous population behaviour is available as
+  `std_err_population`.
+- Degenerate inputs that silently returned `NaN`/`±∞` are now typed
+  errors: zero-variance t-tests and ANOVA, `z_score` with σ ≤ 0, all-zero
+  χ² tables, `p = 1.0` quantiles of unbounded discrete distributions,
+  non-finite distribution parameters in every `new()`, NaN data in
+  `describe`/`quantile`, correlation and rank tests.
+- `Exponential` out-of-support behaviour aligned with the other continuous
+  distributions: `pdf(x<0) = 0`, `cdf(x<0) = 0`, `logpdf(x<0) = −∞`
+  (previously the lone `Err`).
+- Public structs gained fields (`LinearRegression::{x_mean, sum_xx}`,
+  `MultipleLinearRegression` per-coefficient inference,
+  `DecisionTree` internals); struct literals from older versions no longer
+  compile. Saved serde models from v3 still load (`serde(default)`).
+- `LinearRegression::confidence_interval` accepts any level in (0, 1) and
+  now returns a statistically correct Student-t interval of the mean
+  response (hardcoded normal z-scores are gone).
+- `Welford::population_variance` is deprecated in favour of
+  `variance_population`; `variance_sample` added.
+- `DecisionTree` no longer requires `Eq + Hash` on targets
+  (`DecisionTree<f64, f64>` now compiles); the MAE criterion evaluates
+  and predicts medians (its actual minimiser) instead of means.
+- Cargo features introduced: `parallel` (rayon) and `serde`
+  (serde/serde_json/bincode), both enabled by default;
+  `--no-default-features` builds with only `num-traits` + `rand`.
+  Unused `num` dependency removed; `rand_chacha` moved to
+  dev-dependencies; `thiserror` upgraded to 2.
+
+**Added:**
+
+- `sample()` / `sample_n()` on all distributions: ziggurat Normal /
+  LogNormal, Marsaglia-Tsang Gamma (shared by Beta, χ², Student-t, F),
+  Knuth/PTRS Poisson, BINV Binomial, Gamma-Poisson NegativeBinomial.
+- Exact survival functions `sf(x)` on all distributions (full relative
+  precision where `1 − cdf` collapses to 0).
+- New distributions: Cauchy, Laplace, Pareto, Logistic (14 auto-fit
+  candidates) and `MultivariateNormal` (Cholesky-validated, scipy-exact
+  logpdf, Mahalanobis score, `μ + L·z` sampling).
+- Hypothesis tests: Mann-Whitney U, Wilcoxon signed-rank, two-sample
+  Kolmogorov-Smirnov, Fisher exact, D'Agostino-Pearson K² normality test,
+  one-sided `Alternative`s on t-tests, `cohens_d`, `AnovaResult::eta_squared`,
+  `p_adjust` (Bonferroni / Holm / Benjamini-Hochberg).
+- `resampling`: `bootstrap_ci` (percentile) and `permutation_test` for any
+  statistic.
+- Exact power analysis: `power_t_test` / `sample_size_t_test` via a new
+  noncentral-t CDF (Lenth AS 243).
+- Correlation: `pearson` / `spearman` (tie-aware) with significance tests.
+- Descriptive: `describe()` and numpy-compatible `quantile()`.
+- Regression: `prediction_interval`, per-coefficient SE/t/p and global
+  F-test in multiple regression.
+- `utils::linalg::cholesky`; `ln_permutation` / `ln_combination`.
+
+**Fixed:**
+
+- Deep-tail correctness: dynamic quantile brackets (StudentT ν < 2,
+  F(1,1)), `erfc` exact in the far tail, Binomial pmf/cdf at large n,
+  Poisson `ln(k!)` beyond the table, u64-edge combinatorics,
+  `feature_importances` panic, sub-1e-12 quantiles of tiny-shape
+  Gamma/Beta (log-scale root bracketing).
+- Performance: Cody rational erf/erfc, O(1) discrete CDFs, single-pass
+  fit_all diagnostics, Newton quantiles, incremental decision-tree splits
+  (4–25×), multi-accumulator reductions, rayon size thresholds.
+
 ## [v3.0.0](https://github.com/Lsh0x/rs-stats/tree/v3.0.0)
 
 **Breaking changes** — slimmed-down public surface and rayon-default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rs-stats"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,70 +304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,11 +460,10 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rs-stats"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "criterion",
- "num",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -590,7 +525,7 @@ checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -617,6 +552,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,22 +578,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -723,7 +669,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -864,7 +810,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -875,5 +821,5 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-stats"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["LSH <github@lsh.tech>"]
 edition = "2024"
 description = "Statistics library in rust"
@@ -8,21 +8,25 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-num = "0.4.3"
 num-traits = "0.2.19"
 rand = "0.8.5"
-rand_chacha = "0.3.1"
-serde_json = "1.0"
-bincode = "1.3"
-rayon = "1.8"
-thiserror = "1.0"
+thiserror = "2.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+bincode = { version = "1.3", optional = true }
+rayon = { version = "1.8", optional = true }
 
 [features]
-# (rayon is always linked; for single-threaded execution callers can
-#  configure rayon's global thread pool with num_threads(1).)
+default = ["parallel", "serde"]
+# Rayon-backed parallelism for fit_all, decision trees, ANOVA and bulk
+# prediction. Without it, everything runs sequentially (same results).
+parallel = ["dep:rayon"]
+# Serialization: serde derives on models/distributions + save/load helpers
+# (JSON via serde_json, binary via bincode).
+serde = ["dep:serde", "dep:serde_json", "dep:bincode"]
 
 [dev-dependencies]
+rand_chacha = "0.3.1"
 tempfile = "3.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-stats"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["LSH <github@lsh.tech>"]
 edition = "2024"
 description = "Statistics library in rust"

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ println!("95% CI of the difference: [{lo:.1}, {hi:.1}] ms");
 
 ### Distributions
 
-| Continuous | Discrete |
-|---|---|
-| Normal, LogNormal, Exponential, Uniform, Gamma, Weibull, Beta, ChiSquared, StudentT, F | Poisson, Binomial, Geometric, NegativeBinomial |
+| Continuous | Discrete | Multivariate |
+|---|---|---|
+| Normal, LogNormal, Exponential, Uniform, Gamma, Weibull, Beta, ChiSquared, StudentT, F, Cauchy, Laplace, Pareto, Logistic | Poisson, Binomial, Geometric, NegativeBinomial | MultivariateNormal (Cholesky-backed pdf/sample/Mahalanobis) |
 
 Each implements the unified `Distribution` trait:
 
@@ -129,9 +129,28 @@ for f in &ranked {
 
 ### Hypothesis tests
 
-| Parametric | Non-parametric | Categorical |
+| Parametric | Non-parametric & resampling | Categorical & meta |
 |---|---|---|
-| one-sample / two-sample (Student & Welch) / paired t-tests, one-way ANOVA (+ η²) | Mann-Whitney U, Wilcoxon signed-rank, two-sample Kolmogorov-Smirnov | χ² goodness-of-fit, χ² independence, Fisher exact (2×2) |
+| one-sample / two-sample (Student & Welch) / paired t-tests, one-way ANOVA (+ η²), D'Agostino K² normality | Mann-Whitney U, Wilcoxon signed-rank, two-sample Kolmogorov-Smirnov, bootstrap CIs, permutation tests | χ² goodness-of-fit & independence, Fisher exact (2×2), p-value adjustment (Bonferroni / Holm / BH) |
+
+Plus **exact power analysis** through the noncentral t distribution:
+
+```rust
+use rs_stats::hypothesis_tests::{sample_size_t_test, power_t_test, Alternative, TTestKind};
+
+// "How many subjects per arm to detect d = 0.5 at 80% power?"  → 64
+let n = sample_size_t_test(TTestKind::TwoSample, 0.5, 0.05, 0.8, Alternative::TwoSided)?;
+```
+
+And distribution-free inference for **any** statistic:
+
+```rust
+use rs_stats::resampling::{bootstrap_ci, permutation_test};
+use rs_stats::prob::quantile;
+
+// 95% CI for the p90 latency — no closed form needed.
+let ci = bootstrap_ci(&latencies, |s| quantile(s, 0.9).unwrap(), 5000, 0.95, &mut rng)?;
+```
 
 All two-sample tests take `Alternative::{TwoSided, Less, Greater}`; t-test results expose `confidence_interval(level)`; small tables get the exact test:
 
@@ -248,6 +267,13 @@ match Normal::new(0.0, f64::NAN) {
 
 ## What's new in 4.0
 
+- 4 new distributions (Cauchy, Laplace, Pareto, Logistic — 14 auto-fit
+  candidates) + MultivariateNormal with Cholesky sampling
+- Bootstrap confidence intervals & permutation tests for any statistic
+- Exact power / sample-size analysis (noncentral t), D'Agostino K²
+  normality test, multiple-comparison corrections (Bonferroni/Holm/BH)
+- Marsaglia-Tsang gamma sampling — Gamma, Beta, χ², Student-t and F all
+  sample without quantile bisection; ziggurat for Normal/LogNormal
 - `sample()` / `sample_n()` and exact `sf()` on all distributions
 - Pearson / Spearman correlation with significance tests
 - Mann-Whitney U, Wilcoxon signed-rank, two-sample KS, Fisher exact

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```toml
 [dependencies]
-rs-stats = "3.1"
+rs-stats = "4"
 ```
 
 ---
@@ -209,19 +209,29 @@ println!("mean = {}, sample var = {}", w.mean(), w.variance_sample()?);
 
 ```toml
 # Minimal build: just the math, two dependencies (num-traits, rand).
-rs-stats = { version = "3.1", default-features = false }
+rs-stats = { version = "4", default-features = false }
 ```
 
 ## Performance notes
 
-Measured with criterion on the v3.1 refactors (vs v3.0):
+Measured with criterion on the v4.0 refactors (vs v3.0):
 
 | Path | Change |
 |---|---|
+| `erf` / `erfc` / `Normal::cdf` | iterative incomplete gamma → Cody rational approximations: **−69% to −88%** (~2–6 ns/call, ~1 ulp) |
 | `Poisson::cdf`, `NegativeBinomial::cdf` | O(k) sums → **O(1)** closed forms (−99.5% at k = 1000) |
 | `fit_all` | one shared sort + single log-likelihood pass: **−24%** (n = 10⁴) to **−75%** (n = 50) |
 | `StudentT::log_likelihood` (n = 10⁴) | normalization constants hoisted: **−90%** |
 | Decision-tree fit | incremental split sweep: **4–25× faster**, more on larger nodes |
+
+Hot reduction loops use multiple independent accumulators so they pipeline
+and auto-vectorise without `-ffast-math`. For an extra free boost in *your*
+binary, allow the compiler to use your CPU's full instruction set
+(AVX2/FMA/NEON):
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+```
 
 ## Error handling
 
@@ -236,7 +246,7 @@ match Normal::new(0.0, f64::NAN) {
 }
 ```
 
-## What's new in 3.1
+## What's new in 4.0
 
 - `sample()` / `sample_n()` and exact `sf()` on all distributions
 - Pearson / Spearman correlation with significance tests
@@ -247,6 +257,7 @@ match Normal::new(0.0, f64::NAN) {
 - `describe()` / `quantile()` descriptive helpers
 - Decision trees with `f64` targets, incremental splits, median MAE
 - Deep-tail correctness fixes across quantiles, `erfc`, large-n binomials
+- Cody rational `erf`/`erfc` (~1 ulp, up to 8× faster `Normal::cdf`)
 - Cargo features `parallel` / `serde`; leaner dependency tree
 
 Breaking changes: χ² tests now return `ChiSquareResult` (named fields), `std_err` uses the sample convention (`std_err_population` keeps the old one), Exponential's out-of-support behaviour is aligned with the other distributions, and degenerate inputs that used to return NaN/∞ now return errors.

--- a/README.md
+++ b/README.md
@@ -2,642 +2,254 @@
 
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-3.0.0-green.svg)](https://crates.io/crates/rs-stats)
-[![Tests](https://img.shields.io/badge/tests-329%20passing-brightgreen.svg)](https://github.com/lsh0x/rs-stats/actions)
 [![CI](https://github.com/lsh0x/rs-stats/workflows/CI/badge.svg)](https://github.com/lsh0x/rs-stats/actions)
 [![Docs](https://docs.rs/rs-stats/badge.svg)](https://docs.rs/rs-stats)
 [![Crates.io](https://img.shields.io/crates/v/rs-stats.svg)](https://crates.io/crates/rs-stats)
 
-A comprehensive statistical library written in Rust, designed for data scientists, researchers and engineers who need reliable, production-grade statistics.
+**Statistics for Rust that you can actually trust in the tails.**
 
-**rs-stats** covers the full statistical pipeline: probability functions, 14 parametric distributions with MLE/MOM fitting, automatic distribution detection, Kolmogorov-Smirnov goodness-of-fit tests, hypothesis testing, and regression analysis — all **panic-free** via `StatsResult<T>`.
-
----
-
-## Table of Contents
-
-- [Key Features](#-key-features)
-- [Installation](#installation)
-- [Quick Start — Medical Example](#quick-start--medical-example)
-- [Distributions](#distributions)
-  - [Continuous Distributions](#continuous-distributions)
-  - [Discrete Distributions](#discrete-distributions)
-- [Automatic Distribution Fitting](#automatic-distribution-fitting)
-- [Hypothesis Testing](#hypothesis-testing)
-- [Regression Analysis](#regression-analysis)
-- [Error Handling](#error-handling)
-- [Documentation](#documentation)
-
----
-
-## ✨ Key Features
-
-- **14 parametric distributions** — continuous and discrete, each with `fit()` (MLE or MOM), PDF/PMF, CDF, quantile, mean, variance, AIC, BIC
-- **Unified trait interface** — `Distribution` and `DiscreteDistribution` traits enable polymorphism and `Box<dyn Distribution>` at runtime
-- **Auto-fit API** — detect data type, fit all candidates, rank by AIC/BIC/KS-test in a single call
-- **Kolmogorov-Smirnov goodness-of-fit** — continuous and discrete variants
-- **Special functions** — `ln_gamma`, regularized incomplete gamma and beta (Lanczos + Numerical Recipes)
-- **Hypothesis testing** — t-tests (one-sample, two-sample, paired), ANOVA, chi-square, chi-square independence
-- **Regression** — linear, multiple linear, decision trees (regression and classification)
-- **Panic-free** — every computation returns `StatsResult<T>`, ready for production
-
----
-
-## Installation
+14 parametric distributions with a unified `pdf / cdf / sf / quantile / sample` interface, automatic distribution fitting, parametric *and* non-parametric hypothesis tests, correlation, regression with real confidence intervals — every numeric path cross-validated against scipy/numpy, including the extreme-tail regimes where naive implementations silently return `0.0`.
 
 ```toml
 [dependencies]
-rs-stats = "2.0.2"
-```
-
-Or:
-
-```bash
-cargo add rs-stats
+rs-stats = "3.1"
 ```
 
 ---
 
-## Quick Start — Medical Example
+## Sixty seconds of rs-stats
 
-> **Scenario**: You receive anonymised blood pressure measurements from 1 200 patients in a hypertension study. You want to identify the best-fitting distribution, compute the probability of a dangerously high reading, and compare two treatment arms.
+**"What distribution is my data, and how extreme is this new observation?"**
 
 ```rust
-use rs_stats::{auto_fit, fit_all, Distribution};
-use rs_stats::distributions::normal_distribution::Normal;
-use rs_stats::hypothesis_tests::t_test::two_sample_t_test;
-
-// ── Step 1: systolic blood pressure data (mmHg) ──────────────────────────────
-// Real study would have 1 200 values; small sample used for illustration
-let systolic_bp = vec![
-    115.0, 122.0, 118.0, 130.0, 125.0, 119.0, 128.0, 132.0,
-    121.0, 117.0, 126.0, 135.0, 123.0, 120.0, 127.0, 131.0,
-];
-
-// ── Step 2: auto-detect the distribution and find the best fit ────────────────
-let best = auto_fit(&systolic_bp)?;
-println!("Best distribution : {}", best.name);   // → Normal
-println!("  AIC             : {:.2}", best.aic);
-println!("  KS p-value      : {:.4}", best.ks_p_value);
-
-// ── Step 3: use the fitted Normal to answer clinical questions ────────────────
-let bp_dist = Normal::fit(&systolic_bp)?;
-println!("Fitted Normal(μ={:.1}, σ={:.1})", bp_dist.mean(), bp_dist.std_dev());
-
-// P(BP > 140 mmHg) — hypertensive threshold
-let p_hyper = 1.0 - bp_dist.cdf(140.0)?;
-println!("P(BP > 140 mmHg) = {:.2}%", p_hyper * 100.0);
-
-// 95th percentile — what value do 95% of patients fall below?
-let p95 = bp_dist.inverse_cdf(0.95)?;
-println!("95th percentile  = {:.1} mmHg", p95);
-
-// ── Step 4: compare two treatment arms ───────────────────────────────────────
-let control_arm   = vec![128.0, 132.0, 125.0, 130.0, 129.0, 131.0, 127.0, 133.0];
-let treatment_arm = vec![118.0, 122.0, 115.0, 120.0, 119.0, 121.0, 117.0, 123.0];
-
-let t_result = two_sample_t_test(&control_arm, &treatment_arm, false)?;
-println!("Two-sample t-test: t={:.3}, p={:.4}", t_result.t_statistic, t_result.p_value);
-if t_result.p_value < 0.05 {
-    println!("→ Statistically significant BP reduction (α = 0.05)");
-}
-```
-
----
-
-## Distributions
-
-### Continuous Distributions
-
-All continuous distributions implement the `Distribution` trait and expose:
-- `Dist::new(params)` — validated constructor
-- `Dist::fit(data)` — maximum likelihood (MLE) or method-of-moments (MOM) estimation
-- `.pdf(x)`, `.logpdf(x)`, `.cdf(x)`, `.inverse_cdf(p)` — core functions
-- `.mean()`, `.variance()`, `.std_dev()` — moments
-- `.aic(data)`, `.bic(data)` — model selection criteria
-
----
-
-#### Normal — `distributions::normal_distribution::Normal`
-
-> **When to use**: Symmetric continuous measurements that cluster around a mean.
-> **Medical examples**: Blood pressure, height, weight in large populations, IQ scores, measurement errors in lab instruments.
-
-```rust
-use rs_stats::distributions::normal_distribution::Normal;
-use rs_stats::Distribution;
-
-// Diastolic blood pressure in a healthy cohort: N(80, 8)
-let bp = Normal::new(80.0, 8.0)?;
-
-// P(diastolic BP > 90 mmHg) — stage 1 hypertension threshold
-let p_high = 1.0 - bp.cdf(90.0)?;
-println!("P(DBP > 90) = {:.1}%", p_high * 100.0);   // ≈ 10.6%
-
-// 97.5th percentile — upper reference range
-let upper_ref = bp.inverse_cdf(0.975)?;
-println!("Upper reference (97.5th pct) = {:.1} mmHg", upper_ref);  // ≈ 95.7
-
-// Fit to patient data (MLE: μ̂ = mean, σ̂ = pop std-dev)
-let measurements = vec![78.0, 82.0, 79.0, 85.0, 81.0, 77.0, 83.0, 80.0];
-let fitted = Normal::fit(&measurements)?;
-println!("Fitted μ = {:.2}, σ = {:.2}", fitted.mean(), fitted.std_dev());
-```
-
----
-
-#### Log-Normal — `distributions::lognormal::LogNormal`
-
-> **When to use**: Right-skewed positive data — concentrations, durations, biological assays.
-> **Medical examples**: CRP (C-reactive protein) levels, serum creatinine, drug plasma concentrations, tumour volumes, hospital length-of-stay.
-
-```rust
+use rs_stats::{auto_fit, Distribution};
 use rs_stats::distributions::lognormal::LogNormal;
-use rs_stats::Distribution;
 
-// CRP levels (mg/L) in an outpatient cohort
-// CRP is log-normally distributed: healthy < 5, elevated 5–100, critical > 100
-let crp_data = vec![
-    1.2, 0.8, 2.1, 1.5, 45.0, 3.2, 0.9, 12.4, 1.8, 88.0,
-    2.4, 1.1, 5.6, 0.7, 22.3, 3.9, 1.3, 9.7,  0.6,  0.5,
+// Response times (ms) from a production service — right-skewed, as always.
+let latencies = vec![
+    12.1, 14.8, 15.2, 17.9, 19.3, 22.4, 25.1, 28.7, 33.0, 41.2,
+    48.9, 55.3, 71.8, 13.4, 16.0, 18.2, 12.9, 14.1, 96.5, 24.6,
 ];
 
-let crp = LogNormal::fit(&crp_data)?;
-println!("LogNormal(μ={:.2}, σ={:.2})", crp.mu, crp.sigma);
+// One call: detect the type, fit 10 candidate distributions in parallel,
+// rank them by AIC. → LogNormal wins.
+let best = auto_fit(&latencies).unwrap();
+println!("best fit: {} (AIC = {:.1})", best.name, best.aic);
 
-// Median CRP (more informative than mean for skewed data)
-let median = crp.inverse_cdf(0.5)?;
-println!("Median CRP     = {:.2} mg/L", median);
-
-// P(CRP > 10 mg/L) — significant inflammation threshold
-let p_inflamed = 1.0 - crp.cdf(10.0)?;
-println!("P(CRP > 10)    = {:.1}%", p_inflamed * 100.0);
+// Fit it explicitly and ask real questions.
+let dist = LogNormal::fit(&latencies).unwrap();
+let p99      = dist.inverse_cdf(0.99).unwrap();      // latency budget
+let p_beyond = dist.sf(250.0).unwrap();              // P(X > 250 ms), exact tail
+println!("p99 = {p99:.1} ms, P(>250ms) = {p_beyond:.2e}");
 ```
 
----
-
-#### Weibull — `distributions::weibull::Weibull`
-
-> **When to use**: Time-to-event data where the hazard rate changes over time.
-> **Medical examples**: Time to relapse after cancer treatment, medical device/implant survival, time until a drug loses efficacy, organ transplant survival.
+**"Simulate from it."** Every distribution samples through the same trait:
 
 ```rust
-use rs_stats::distributions::weibull::Weibull;
 use rs_stats::Distribution;
+use rs_stats::distributions::normal_distribution::Normal;
+use rand::SeedableRng;
 
-// Time to relapse (months) after chemotherapy — k > 1 means increasing hazard
-let relapse_times = vec![3.1, 7.4, 12.5, 2.8, 18.2, 5.9, 9.6, 15.3, 4.2, 22.0];
-
-let w = Weibull::fit(&relapse_times)?;
-println!("Weibull(k={:.2}, λ={:.2})", w.k, w.lambda);
-// k > 1 → hazard rate increases over time (survivors become more at risk)
-
-// Median relapse-free survival
-let median_rfs = w.inverse_cdf(0.5)?;
-println!("Median relapse-free survival = {:.1} months", median_rfs);
-
-// P(relapse within 6 months) — short-term risk
-let p_6mo = w.cdf(6.0)?;
-println!("P(relapse < 6 months)        = {:.1}%", p_6mo * 100.0);
-
-// 1-year survival probability
-let p_1yr = 1.0 - w.cdf(12.0)?;
-println!("1-year relapse-free survival = {:.1}%", p_1yr * 100.0);
+let d = Normal::new(100.0, 15.0).unwrap();
+let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42); // reproducible
+let draws = d.sample_n(&mut rng, 10_000).unwrap();
 ```
 
----
-
-#### Gamma — `distributions::gamma_distribution::Gamma`
-
-> **When to use**: Positive right-skewed data, especially waiting times or accumulated effects.
-> **Medical examples**: ICU length-of-stay, time between hospital readmissions, blood glucose AUC in OGTT.
-
-```rust
-use rs_stats::distributions::gamma_distribution::Gamma;
-use rs_stats::Distribution;
-
-// ICU length-of-stay (days) — Gamma naturally models positive skewed durations
-let icu_los = vec![
-    1.5, 2.0, 4.5, 1.2, 7.8, 3.1, 2.4, 10.2, 1.8, 5.6,
-    3.9, 2.1, 6.3, 1.4, 8.9, 4.0, 2.7,  3.5, 1.9, 12.1,
-];
-
-let gamma = Gamma::fit(&icu_los)?;
-println!("Gamma(α={:.2}, β={:.2})", gamma.alpha, gamma.beta);
-println!("Mean ICU stay   = {:.2} days", gamma.mean());
-println!("Std-dev         = {:.2} days", gamma.std_dev());
-
-// P(LOS > 7 days) — prolonged ICU stay threshold for resource planning
-let p_prolonged = 1.0 - gamma.cdf(7.0)?;
-println!("P(LOS > 7 days) = {:.1}%", p_prolonged * 100.0);
-```
-
----
-
-#### Beta — `distributions::beta::Beta`
-
-> **When to use**: Proportions, rates, and probabilities bounded in (0, 1).
-> **Medical examples**: Diagnostic test sensitivity and specificity, medication adherence rates, tumour response rates, proportion of time in therapeutic range (TTR) for anticoagulant patients.
-
-```rust
-use rs_stats::distributions::beta::Beta;
-use rs_stats::Distribution;
-
-// Time-in-therapeutic-range (TTR) for warfarin patients (values in 0–1)
-// TTR ≥ 0.70 is considered well-controlled anticoagulation
-let ttr_data = vec![
-    0.72, 0.65, 0.88, 0.55, 0.91, 0.78, 0.62, 0.84,
-    0.70, 0.58, 0.79, 0.93, 0.67, 0.75, 0.48, 0.82,
-];
-
-let beta = Beta::fit(&ttr_data)?;
-println!("Beta(α={:.2}, β={:.2})", beta.alpha, beta.beta);
-
-// P(TTR ≥ 0.70) — probability of being well-controlled
-let p_well = 1.0 - beta.cdf(0.70)?;
-println!("P(TTR ≥ 0.70) = {:.1}%", p_well * 100.0);
-
-// Median TTR across the population
-let median_ttr = beta.inverse_cdf(0.5)?;
-println!("Median TTR    = {:.1}%", median_ttr * 100.0);
-```
-
----
-
-#### Student's t — `distributions::student_t::StudentT`
-
-> **When to use**: Symmetric distributions with heavier tails than Normal; small-sample inference.
-> **Medical examples**: Standardised effect sizes in small pilot studies, residuals from mixed-effects models, computing critical values for paired-samples tests.
-
-```rust
-use rs_stats::distributions::student_t::StudentT;
-use rs_stats::Distribution;
-
-// Small diabetes pilot study (n=12): t-distribution with df = n-1 = 11
-let t_dist = StudentT::new(0.0, 1.0, 11.0)?;
-
-// Two-sided critical value at α = 0.05
-let t_crit = t_dist.inverse_cdf(0.975)?;
-println!("t-critical (α=0.05, df=11) = {:.3}", t_crit);   // ≈ 2.201
-
-// p-value for an observed t-statistic of 2.5 (two-tailed)
-let p_value = 2.0 * (1.0 - t_dist.cdf(2.5)?);
-println!("p-value for |t|=2.5        = {:.4}", p_value);
-```
-
----
-
-#### Exponential — `distributions::exponential_distribution::Exponential`
-
-> **When to use**: Time between events when events occur at a constant rate (memoryless property).
-> **Medical examples**: Inter-arrival times in an emergency department, time between seizures in epilepsy patients, spontaneous adverse events during a trial.
-
-```rust
-use rs_stats::distributions::exponential_distribution::Exponential;
-use rs_stats::Distribution;
-
-// Time (minutes) between patient arrivals in an ED
-let inter_arrivals = vec![8.2, 12.5, 4.1, 9.8, 6.3, 15.0, 3.7, 11.2, 7.4, 9.1];
-
-let exp = Exponential::fit(&inter_arrivals)?;
-println!("Exponential(λ={:.3} arrivals/min)", exp.lambda);
-println!("Mean inter-arrival = {:.1} min", exp.mean());
-
-// P(next patient within 5 minutes) — triage planning
-let p_5min = exp.cdf(5.0)?;
-println!("P(arrival < 5 min) = {:.1}%", p_5min * 100.0);
-```
-
----
-
-#### Chi-Squared — `distributions::chi_squared::ChiSquared`
-
-> **When to use**: Distribution of sums of squared standard normals; used in goodness-of-fit tests and variance confidence intervals.
-> **Medical examples**: Testing whether observed disease frequencies match expected proportions, variance confidence intervals for measurement devices.
-
-```rust
-use rs_stats::distributions::chi_squared::ChiSquared;
-use rs_stats::Distribution;
-
-// 6-category goodness-of-fit test: df = 6 - 1 = 5
-let chi2 = ChiSquared::new(5.0)?;
-
-// Critical value at α = 0.05
-let chi2_crit = chi2.inverse_cdf(0.95)?;
-println!("χ²(5) critical value (α=0.05) = {:.3}", chi2_crit);  // ≈ 11.07
-
-// p-value for an observed χ² = 9.2
-let p_value = 1.0 - chi2.cdf(9.2)?;
-println!("p-value for χ²=9.2            = {:.4}", p_value);
-```
-
----
-
-#### F-Distribution — `distributions::f_distribution::FDistribution`
-
-> **When to use**: Ratio of two chi-squared variables; used in ANOVA and regression significance tests.
-> **Medical examples**: Comparing biomarker variance across patient groups, multi-arm ANOVA F-statistic, F-test in multiple regression predicting clinical outcomes.
-
-```rust
-use rs_stats::distributions::f_distribution::FDistribution;
-use rs_stats::Distribution;
-
-// ANOVA with 4 groups, total n=52: F(3, 48)
-let f_dist = FDistribution::new(3.0, 48.0)?;
-
-// Critical value at α = 0.05
-let f_crit = f_dist.inverse_cdf(0.95)?;
-println!("F(3,48) critical value (α=0.05) = {:.3}", f_crit);  // ≈ 2.80
-
-// p-value for observed F = 4.5
-let p_value = 1.0 - f_dist.cdf(4.5)?;
-println!("p-value for F=4.5               = {:.4}", p_value);
-```
-
----
-
-#### Uniform — `distributions::uniform_distribution::Uniform`
-
-> **When to use**: All values in a range are equally likely.
-> **Medical examples**: Randomisation checks in clinical trials, uncertainty about a drug's effective window, boundary-condition stress testing.
-
-```rust
-use rs_stats::distributions::uniform_distribution::Uniform;
-use rs_stats::Distribution;
-
-// Drug release window: effective between 2 h and 6 h post-ingestion
-let release = Uniform::new(2.0, 6.0)?;
-
-// P(effective within the first 3 hours)
-let p_3h = release.cdf(3.0)?;
-println!("P(effective by 3h) = {:.1}%", p_3h * 100.0);  // 25%
-```
-
----
-
-### Discrete Distributions
-
-All discrete distributions implement the `DiscreteDistribution` trait and expose:
-- `Dist::new(params)` — validated constructor
-- `Dist::fit(data)` — MLE or MOM from `&[f64]`
-- `.pmf(k)`, `.logpmf(k)`, `.cdf(k)` — core functions
-- `.mean()`, `.variance()`, `.std_dev()` — moments
-- `.aic(data)`, `.bic(data)` — model selection
-
----
-
-#### Poisson — `distributions::poisson_distribution::Poisson`
-
-> **When to use**: Count of rare independent events in a fixed time or space window.
-> **Medical examples**: Adverse drug reactions per 1 000 prescriptions, surgical site infections per month, emergency calls per hour, mutations per cell division.
-
-```rust
-use rs_stats::distributions::poisson_distribution::Poisson;
-use rs_stats::DiscreteDistribution;
-
-// Hospital-acquired infections (HAI) per ward per month: λ = 2.3
-let hai = Poisson::new(2.3)?;
-
-println!("P(0 HAI)     = {:.1}%", hai.pmf(0)? * 100.0);   // ≈ 10.0%
-println!("P(≥5 HAI)    = {:.1}%", (1.0 - hai.cdf(4)?) * 100.0);  // alert threshold
-
-// Fit from 12 months of observed counts
-let monthly_counts = vec![1.0, 3.0, 2.0, 0.0, 4.0, 2.0, 1.0, 3.0, 2.0, 1.0, 5.0, 2.0];
-let fitted = Poisson::fit(&monthly_counts)?;
-println!("Estimated λ  = {:.2} infections/month", fitted.lambda);
-```
-
----
-
-#### Binomial — `distributions::binomial_distribution::Binomial`
-
-> **When to use**: Number of successes in n independent trials with constant probability p.
-> **Medical examples**: Responders in a treatment cohort, positive tests in a screening batch, side-effect events in a treated group.
-
-```rust
-use rs_stats::distributions::binomial_distribution::Binomial;
-use rs_stats::DiscreteDistribution;
-
-// Trial: n=100 patients, literature response rate p=0.35
-let trial = Binomial::new(100, 0.35)?;
-
-println!("E[responders]   = {:.0}", trial.mean());   // 35
-
-// P(≥ 45 responders) — detect a meaningful improvement
-let p_improved = 1.0 - trial.cdf(44)?;
-println!("P(≥45 respond)  = {:.2}%", p_improved * 100.0);
-```
-
----
-
-#### Geometric — `distributions::geometric::Geometric`
-
-> **When to use**: Number of trials until the first success (k ≥ 1).
-> **Medical examples**: Screening cycles until a lesion is detected, treatment attempts until remission, needle passes until a successful lumbar puncture.
-
-```rust
-use rs_stats::distributions::geometric::Geometric;
-use rs_stats::DiscreteDistribution;
-
-// Colonoscopy screening: P(detecting polyp per session) = 0.18
-let screening = Geometric::new(0.18)?;
-
-println!("E[sessions to detect] = {:.1}", screening.mean());   // ≈ 5.6
-let p_within_3 = screening.cdf(3)?;
-println!("P(detected ≤ 3 sessions) = {:.1}%", p_within_3 * 100.0);
-```
-
----
-
-#### Negative Binomial — `distributions::negative_binomial::NegativeBinomial`
-
-> **When to use**: Overdispersed count data (variance > mean), or number of failures before r-th success.
-> **Medical examples**: Hospitalisations before stable remission, overdispersed adverse event counts, recurrences before sustained response.
-
-```rust
-use rs_stats::distributions::negative_binomial::NegativeBinomial;
-use rs_stats::DiscreteDistribution;
-
-// Re-admissions before stable remission — overdispersed (variance > mean)
-let admissions = vec![
-    0.0, 2.0, 1.0, 5.0, 3.0, 0.0, 4.0, 1.0, 2.0, 6.0,
-    1.0, 0.0, 3.0, 2.0, 1.0, 4.0, 0.0, 2.0, 3.0, 1.0,
-];
-
-let nb = NegativeBinomial::fit(&admissions)?;
-println!("NegBin(r={:.2}, p={:.3})", nb.r, nb.p);
-println!("Mean re-admissions = {:.2}", nb.mean());
-println!("P(0 re-admissions) = {:.1}%", nb.pmf(0)? * 100.0);
-```
-
----
-
-## Automatic Distribution Fitting
-
-> **Scenario**: A pharmacokineticist wants to know which distribution best describes drug half-life across 80 patients, without assuming Normality.
-
-```rust
-use rs_stats::{auto_fit, fit_all};
-
-// Drug half-life (hours) — typically log-normal or Weibull in PK studies
-let half_lives = vec![
-    4.2, 6.1, 3.8, 9.5, 5.3, 7.4, 4.9, 11.2, 3.5, 6.8,
-    8.1, 4.4, 5.7, 7.0, 3.9, 10.3, 5.1,  6.5, 4.7,  8.6,
-];
-
-// One-call: auto-detect type + best AIC
-let best = auto_fit(&half_lives)?;
-println!("Best fit: {} (AIC={:.2}, KS p={:.3})", best.name, best.aic, best.ks_p_value);
-
-// Full ranking — compare all candidates
-println!("\n{:<15} {:>8} {:>8} {:>10}", "Distribution", "AIC", "BIC", "KS p-value");
-println!("{}", "-".repeat(45));
-for r in fit_all(&half_lives)? {
-    println!("{:<15} {:>8.2} {:>8.2} {:>10.4}", r.name, r.aic, r.bic, r.ks_p_value);
-}
-// Typical output:
-// Distribution    AIC      BIC   KS p-value
-// -----------------------------------------
-// LogNormal     82.34    84.12     0.8231
-// Gamma         83.71    85.49     0.7654
-// Weibull       84.02    85.80     0.7412
-// Normal        89.45    91.23     0.4103
-```
-
-### Available candidates
-
-| Type | Distributions |
-|------|--------------|
-| Continuous (`fit_all`) | Normal, Exponential, Uniform, Gamma, LogNormal, Weibull, Beta, StudentT, F, ChiSquared |
-| Discrete (`fit_all_discrete`) | Poisson, Geometric, NegativeBinomial, Binomial |
-
----
-
-## Hypothesis Testing
-
-> **Scenario**: A clinical trial compares HbA1c reduction across three diabetes treatments.
+**"Did the change actually help?"** Parametric or not, with one-sided alternatives and effect sizes:
 
 ```rust
 use rs_stats::hypothesis_tests::{
-    t_test::{one_sample_t_test, two_sample_t_test, paired_t_test},
-    anova::one_way_anova,
-    chi_square_test::chi_square_independence,
+    Alternative, mann_whitney_u, two_sample_t_test_alt, cohens_d,
 };
 
-// ── Paired t-test: before vs after treatment ──────────────────────────────────
-let before = vec![8.2, 7.9, 8.6, 9.1, 8.4, 8.0, 8.8, 9.3];  // HbA1c %
-let after  = vec![7.4, 7.1, 7.9, 8.3, 7.5, 7.2, 8.0, 8.5];
-let paired = paired_t_test(&before, &after)?;
-println!("Paired t-test: t={:.3}, p={:.4}", paired.t_statistic, paired.p_value);
-// p < 0.05 → significant reduction in HbA1c
+let before = [212.0, 198.5, 205.1, 220.8, 199.9, 210.4, 215.2, 202.7];
+let after  = [188.2, 179.4, 195.0, 183.6, 176.9, 190.1, 181.3, 186.5];
 
-// ── One-way ANOVA: compare three treatment arms ───────────────────────────────
-let drug_a = vec![-0.8, -1.2, -0.5, -1.5, -0.9];  // HbA1c change %
-let drug_b = vec![-1.4, -1.8, -1.1, -2.0, -1.6];
-let drug_c = vec![-0.4, -0.6, -0.3, -0.8, -0.5];
-let groups: Vec<&[f64]> = vec![&drug_a, &drug_b, &drug_c];
-let anova = one_way_anova(&groups)?;
-println!("ANOVA: F={:.3}, p={:.4}", anova.f_statistic, anova.p_value);
+// Welch's t-test, H₁: "after" is lower.
+let t = two_sample_t_test_alt(&after, &before, false, Alternative::Less).unwrap();
+// Distribution-free cross-check.
+let u = mann_whitney_u(&after, &before, Alternative::Less).unwrap();
+let d = cohens_d(&before, &after).unwrap();
 
-// ── Chi-square independence: side-effect rate by treatment ────────────────────
-// Rows: Drug A, B, C  |  Cols: No side-effect, Side-effect occurred
-let observed = vec![
-    vec![42, 8],   // Drug A
-    vec![36, 14],  // Drug B
-    vec![45, 5],   // Drug C
-];
-let (_chi2, _df, p) = chi_square_independence(&observed)?;
-println!("χ² independence: p={:.4}", p);
+println!("t-test p = {:.2e}, Mann-Whitney p = {:.2e}, Cohen's d = {d:.2}",
+         t.p_value, u.p_value);
+let (lo, hi) = t.confidence_interval(0.95).unwrap();
+println!("95% CI of the difference: [{lo:.1}, {hi:.1}] ms");
 ```
 
 ---
 
-## Regression Analysis
+## Why this library
 
-> **Scenario**: Predict post-operative recovery time from patient characteristics.
+**Tails you can quote.** `sf(x)` (survival function) has an exact closed form on all 14 distributions — `Normal.sf(10.0)` returns `7.6e-24`, not `0.0`. p-values, `erfc`, and the incomplete gamma/beta tails keep full *relative* precision where `1.0 - cdf(x)` collapses. Quantile brackets expand dynamically, so heavy-tailed quantiles (Student-t with ν < 2, F with small denominators) are correct instead of silently clamped.
+
+**Cross-validated against scipy/numpy.** Every distribution (pdf, cdf, sf, quantiles, log-likelihoods), every test statistic and p-value, every regression output is checked against scipy/numpy references — on friendly inputs *and* hostile ones: quantiles at 10⁻⁶, n = 5000 binomials, u64-edge combinatorics, ν = 0.5 Student-t.
+
+**Fast where it matters.** Discrete CDFs are O(1) closed forms (regularized incomplete gamma/beta). `fit_all` sorts once, shares it across all KS tests, and computes each log-likelihood exactly once. Decision-tree split search is a single incremental sweep. Rayon parallelism kicks in only past size thresholds where it actually wins.
+
+**Panic-free, feature-gated.** All fallible operations return `StatsResult<T>`. Degenerate inputs (zero variance, NaN parameters, all-zero tables) are typed errors, not NaN propagation. `--no-default-features` gives you the pure math with just `num-traits` and `rand`.
+
+---
+
+## Tour
+
+### Distributions
+
+| Continuous | Discrete |
+|---|---|
+| Normal, LogNormal, Exponential, Uniform, Gamma, Weibull, Beta, ChiSquared, StudentT, F | Poisson, Binomial, Geometric, NegativeBinomial |
+
+Each implements the unified `Distribution` trait:
+
+```rust
+use rs_stats::Distribution;
+use rs_stats::distributions::gamma_distribution::Gamma;
+
+let g = Gamma::fit(&data)?;             // MLE / method-of-moments
+g.pdf(x)?;      g.logpdf(x)?;           // density (log-space stable)
+g.cdf(x)?;      g.sf(x)?;               // CDF and exact upper tail
+g.inverse_cdf(0.999)?;                  // quantiles
+g.sample(&mut rng)?;                    // random draws
+g.mean();  g.variance();  g.aic(&data)?;  g.bic(&data)?;
+```
+
+The trait is object-safe: `Box<dyn Distribution<X = f64>>` works for runtime polymorphism (`X = u64` for the discrete family).
+
+### Automatic fitting
+
+```rust
+use rs_stats::{fit_all, fit_all_verbose};
+
+let ranked = fit_all(&data)?;                  // all candidates, sorted by AIC
+let (fits, skipped) = fit_all_verbose(&data)?; // + why each candidate failed
+for f in &ranked {
+    println!("{:<12} AIC={:>8.1}  KS p={:.3}", f.name, f.aic, f.ks_p_value);
+}
+```
+
+### Hypothesis tests
+
+| Parametric | Non-parametric | Categorical |
+|---|---|---|
+| one-sample / two-sample (Student & Welch) / paired t-tests, one-way ANOVA (+ η²) | Mann-Whitney U, Wilcoxon signed-rank, two-sample Kolmogorov-Smirnov | χ² goodness-of-fit, χ² independence, Fisher exact (2×2) |
+
+All two-sample tests take `Alternative::{TwoSided, Less, Greater}`; t-test results expose `confidence_interval(level)`; small tables get the exact test:
+
+```rust
+use rs_stats::hypothesis_tests::{fisher_exact, Alternative};
+
+// Responders: treatment 8/10, control 1/6 — too small for χ².
+let r = fisher_exact(8, 2, 1, 5, Alternative::TwoSided)?;
+println!("odds ratio = {:.0}, exact p = {:.4}", r.odds_ratio, r.p_value);
+```
+
+### Correlation & descriptive statistics
+
+```rust
+use rs_stats::prob::{pearson_test, spearman, describe, quantile};
+
+let r = pearson_test(&x, &y)?;          // r, t-statistic, p-value
+let rho = spearman(&x, &y)?;            // rank correlation, tie-aware
+
+let d = describe(&data)?;               // n, mean, std-dev, min/Q1/median/Q3/max
+let p95 = quantile(&data, 0.95)?;       // numpy-compatible interpolation
+```
+
+### Regression
 
 ```rust
 use rs_stats::regression::linear_regression::LinearRegression;
 use rs_stats::regression::multiple_linear_regression::MultipleLinearRegression;
 
-// ── Simple linear regression: age → recovery time ────────────────────────────
-let age           = vec![35.0, 45.0, 55.0, 62.0, 70.0, 48.0, 58.0, 40.0];
-let recovery_days = vec![ 4.0,  5.5,  7.0,  8.5, 10.0,  6.0,  7.5,  5.0];
+let mut lr = LinearRegression::<f64>::new();
+lr.fit(&x, &y)?;
+let (lo, hi) = lr.confidence_interval(x0, 0.95)?;   // CI of the mean response
+let (plo, phi) = lr.prediction_interval(x0, 0.95)?; // bounds for one new point
 
-let mut model = LinearRegression::new();
-model.fit(&age, &recovery_days)?;
-println!("Recovery ~ Age: slope={:.3} d/yr, R²={:.4}", model.slope, model.r_squared);
-
-// Predict for a 52-year-old patient with 95% CI
-let predicted = model.predict(52.0);
-let (lo, hi)  = model.confidence_interval(52.0, 0.95)?;
-println!("Predicted (age=52): {:.1} days  95% CI [{:.1}, {:.1}]", predicted, lo, hi);
-
-// ── Multiple regression: age + BMI + comorbidity score → recovery ─────────────
-let features = vec![
-    vec![35.0, 23.0, 1.0],   // [age, BMI, comorbidity score]
-    vec![55.0, 28.0, 2.0],
-    vec![62.0, 31.0, 3.0],
-    vec![45.0, 25.0, 1.0],
-    vec![70.0, 33.0, 4.0],
-    vec![48.0, 26.0, 2.0],
-];
-let outcomes = vec![4.5, 7.2, 9.8, 5.1, 12.3, 6.4];
-
-let mut mlr = MultipleLinearRegression::new();
-mlr.fit(&features, &outcomes)?;
-println!("MLR R² = {:.4}, Adj. R² = {:.4}", mlr.r_squared, mlr.adjusted_r_squared);
+let mut mlr = MultipleLinearRegression::<f64>::new();
+mlr.fit(&rows, &y)?;
+// Per-coefficient inference, like a real stats package:
+for (i, (se, p)) in mlr.coefficient_std_errors.iter().zip(&mlr.p_values).enumerate() {
+    println!("β{i} = {:.3} (SE {:.3}, p = {:.4})", mlr.coefficients[i], se, p);
+}
+println!("F = {:.1} (p = {:.2e})", mlr.f_statistic, mlr.f_p_value);
 ```
 
----
-
-## Error Handling
-
-All functions return `StatsResult<T>` — a type alias for `Result<T, StatsError>`. The library **never panics**.
+Decision trees (CART) handle regression **and** classification with plain `f64` targets — `DecisionTree<f64, f64>` — using incremental split search (running sums for MSE, class-count arrays for Gini/entropy) and a median-based MAE criterion:
 
 ```rust
-use rs_stats::{StatsError, StatsResult};
+use rs_stats::regression::decision_tree::{DecisionTree, SplitCriterion, TreeType};
+
+let mut tree = DecisionTree::<f64, f64>::new(TreeType::Regression, SplitCriterion::Mse, 8, 4, 2);
+tree.fit(&features, &targets)?;
+let preds = tree.predict(&new_features)?;
+let importances = tree.feature_importances();
+```
+
+### Streaming statistics
+
+Welford online estimators for data that doesn't fit in memory (or arrives one point at a time): scalar, per-axis vector, and full covariance-matrix variants, all with O(1)/O(D²) updates, `merge()` for parallel reduction, and zero steady-state allocation.
+
+```rust
+use rs_stats::prob::welford::Welford;
+
+let mut w = Welford::new();
+for x in stream { w.push(x); }
+println!("mean = {}, sample var = {}", w.mean(), w.variance_sample()?);
+```
+
+---
+
+## Cargo features
+
+| Feature | Default | What it adds |
+|---|---|---|
+| `parallel` | ✅ | Rayon-backed parallelism (`fit_all`, decision trees, ANOVA, bulk predict) with sequential fallbacks below size thresholds |
+| `serde` | ✅ | Serde derives on distributions and models + `save`/`load`/`to_json` persistence |
+
+```toml
+# Minimal build: just the math, two dependencies (num-traits, rand).
+rs-stats = { version = "3.1", default-features = false }
+```
+
+## Performance notes
+
+Measured with criterion on the v3.1 refactors (vs v3.0):
+
+| Path | Change |
+|---|---|
+| `Poisson::cdf`, `NegativeBinomial::cdf` | O(k) sums → **O(1)** closed forms (−99.5% at k = 1000) |
+| `fit_all` | one shared sort + single log-likelihood pass: **−24%** (n = 10⁴) to **−75%** (n = 50) |
+| `StudentT::log_likelihood` (n = 10⁴) | normalization constants hoisted: **−90%** |
+| Decision-tree fit | incremental split sweep: **4–25× faster**, more on larger nodes |
+
+## Error handling
+
+Everything fallible returns `StatsResult<T> = Result<T, StatsError>`, with typed variants (`InvalidInput`, `InvalidParameter`, `DimensionMismatch`, `EmptyData`, `ConversionError`, `NumericalError`, `NotFitted`, …). Degenerate inputs — zero-variance t-tests, all-zero χ² tables, `z_score` with σ = 0, non-finite distribution parameters — are **errors**, never silent NaN or ±∞.
+
+```rust
 use rs_stats::distributions::normal_distribution::Normal;
-use rs_stats::Distribution;
 
-fn reference_range(mean: f64, sd: f64) -> StatsResult<(f64, f64)> {
-    let dist  = Normal::new(mean, sd)?;          // Err if sd ≤ 0
-    let lower = dist.inverse_cdf(0.025)?;
-    let upper = dist.inverse_cdf(0.975)?;
-    Ok((lower, upper))
-}
-
-match reference_range(80.0, -5.0) {             // Invalid: negative SD
-    Ok((lo, hi)) => println!("Ref range: [{:.1}, {:.1}]", lo, hi),
-    Err(StatsError::InvalidInput { message }) =>
-        println!("Invalid params: {}", message), // → "Normal::new: std_dev must be positive"
-    Err(e) => println!("Error: {}", e),
+match Normal::new(0.0, f64::NAN) {
+    Err(e) => eprintln!("caught: {e}"), // "Normal::new: parameters must be finite"
+    Ok(_) => unreachable!(),
 }
 ```
 
-### Error Variants
+## What's new in 3.1
 
-| Variant | Raised when |
-|---------|-------------|
-| `InvalidInput` | Out-of-domain parameter (negative σ, p ∉ [0,1], …) |
-| `EmptyData` | Empty slice passed to `fit()` or statistical functions |
-| `DimensionMismatch` | Mismatched array lengths (regression, paired tests) |
-| `ConversionError` | Type conversion failures |
-| `NumericalError` | Numerical instability (overflow, NaN propagation) |
-| `NotFitted` | `predict()` called before `fit()` on a regression model |
+- `sample()` / `sample_n()` and exact `sf()` on all distributions
+- Pearson / Spearman correlation with significance tests
+- Mann-Whitney U, Wilcoxon signed-rank, two-sample KS, Fisher exact
+- One-sided alternatives + confidence intervals on t-tests; Cohen's d, η²
+- Per-coefficient SE / t / p and global F-test in multiple regression
+- Real Student-t confidence *and* prediction intervals in linear regression
+- `describe()` / `quantile()` descriptive helpers
+- Decision trees with `f64` targets, incremental splits, median MAE
+- Deep-tail correctness fixes across quantiles, `erfc`, large-n binomials
+- Cargo features `parallel` / `serde`; leaner dependency tree
 
----
-
-## Documentation
-
-```bash
-cargo doc --open          # full API documentation
-cargo test                # 343 unit tests + 66 doc tests
-cargo clippy              # linting
-cargo fmt --check         # formatting
-```
-
----
+Breaking changes: χ² tests now return `ChiSquareResult` (named fields), `std_err` uses the sample convention (`std_err_population` keeps the old one), Exponential's out-of-support behaviour is aligned with the other distributions, and degenerate inputs that used to return NaN/∞ now return errors.
 
 ## Contributing
 
@@ -647,8 +259,6 @@ cargo fmt --check         # formatting
 4. Push and open a pull request
 
 All PRs must pass `cargo test`, `cargo clippy -- -D warnings`, and `cargo fmt --check`.
-
----
 
 ## License
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -266,12 +266,56 @@ mod fitting {
     }
 }
 
+// ── Decision tree ─────────────────────────────────────────────────────────────
+mod tree {
+    use criterion::{BenchmarkId, Criterion, black_box};
+    use rs_stats::regression::decision_tree::{DecisionTree, SplitCriterion, TreeType};
+
+    pub fn bench_tree_fit(c: &mut Criterion) {
+        let mut group = c.benchmark_group("tree_fit");
+        group.sample_size(10);
+        for n in [500_usize, 2000] {
+            let features: Vec<Vec<i32>> = (0..n)
+                .map(|i| (0..6).map(|f| ((i * 37 + f * 101) % 997) as i32).collect())
+                .collect();
+            let target_reg: Vec<i32> = (0..n).map(|i| ((i * 53) % 211) as i32).collect();
+            group.bench_with_input(BenchmarkId::new("mse", n), &n, |b, _| {
+                b.iter(|| {
+                    let mut t = DecisionTree::<i32, f64>::new(
+                        TreeType::Regression,
+                        SplitCriterion::Mse,
+                        8,
+                        4,
+                        2,
+                    );
+                    t.fit(black_box(&features), black_box(&target_reg)).unwrap();
+                });
+            });
+            let target_cls: Vec<i32> = (0..n).map(|i| ((i * 7) % 5) as i32).collect();
+            group.bench_with_input(BenchmarkId::new("gini", n), &n, |b, _| {
+                b.iter(|| {
+                    let mut t = DecisionTree::<i32, f64>::new(
+                        TreeType::Classification,
+                        SplitCriterion::Gini,
+                        8,
+                        4,
+                        2,
+                    );
+                    t.fit(black_box(&features), black_box(&target_cls)).unwrap();
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
 criterion_group!(
     benches,
     poisson::bench_pmf,
     poisson::bench_cdf,
     fitting::bench_fit_all,
     fitting::bench_student_log_likelihood,
+    tree::bench_tree_fit,
     binomial::bench_cdf,
     binomial::bench_pmf,
     hypothesis::bench_paired_t_test,

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -225,10 +225,53 @@ mod combinatorics {
     }
 }
 
+// ── Distribution fitting ──────────────────────────────────────────────────────
+mod fitting {
+    use criterion::{BenchmarkId, Criterion, black_box};
+    use rs_stats::Distribution;
+    use rs_stats::distributions::student_t::StudentT;
+
+    fn lognormal_ish(n: usize) -> Vec<f64> {
+        // Deterministic right-skewed positive data (no rng dependency).
+        (0..n)
+            .map(|i| {
+                let u = (i as f64 + 0.5) / n as f64;
+                (2.0 * u).exp() * (1.0 + 0.1 * (i as f64).sin())
+            })
+            .collect()
+    }
+
+    pub fn bench_fit_all(c: &mut Criterion) {
+        let mut group = c.benchmark_group("fit_all");
+        group.sample_size(20);
+        for n in [50, 1000, 10_000] {
+            let data = lognormal_ish(n);
+            group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+                b.iter(|| rs_stats::fit_all(black_box(&data)));
+            });
+        }
+        group.finish();
+    }
+
+    pub fn bench_student_log_likelihood(c: &mut Criterion) {
+        let mut group = c.benchmark_group("student_log_likelihood");
+        let dist = StudentT::new(0.0, 1.0, 5.0).unwrap();
+        for n in [1000, 10_000] {
+            let data: Vec<f64> = (0..n).map(|i| ((i as f64) * 0.37).sin() * 3.0).collect();
+            group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+                b.iter(|| dist.log_likelihood(black_box(&data)));
+            });
+        }
+        group.finish();
+    }
+}
+
 criterion_group!(
     benches,
     poisson::bench_pmf,
     poisson::bench_cdf,
+    fitting::bench_fit_all,
+    fitting::bench_student_log_likelihood,
     binomial::bench_cdf,
     binomial::bench_pmf,
     hypothesis::bench_paired_t_test,

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -73,7 +73,7 @@ impl Beta {
     /// Creates a `Beta(α, β)` distribution. Both parameters must be positive.
     pub fn new(alpha: f64, beta: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !alpha.is_finite() || !beta.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Beta::new: parameters must be finite".to_string(),

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -143,6 +143,24 @@ impl Distribution for Beta {
         )
     }
 
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // ln B(α, β) (3 ln_gamma) hoisted out of the per-point loop.
+        let log_norm = -ln_beta(self.alpha, self.beta);
+        let (a1, b1) = (self.alpha - 1.0, self.beta - 1.0);
+        let mut acc = 0.0_f64;
+        for &x in data {
+            if x <= 0.0 || x >= 1.0 {
+                return f64::NEG_INFINITY;
+            }
+            acc += a1 * x.ln() + b1 * (1.0 - x).ln();
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
     fn cdf(&self, x: f64) -> StatsResult<f64> {
         if x <= 0.0 {
             return Ok(0.0);

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -48,7 +48,7 @@
 
 use crate::distributions::traits::Distribution;
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::{bisect_inverse_cdf, ln_beta, regularized_incomplete_beta};
+use crate::utils::special_functions::{ln_beta, regularized_incomplete_beta};
 
 /// Beta distribution Beta(α, β).
 ///
@@ -212,8 +212,9 @@ impl Distribution for Beta {
         }
         let alpha = self.alpha;
         let beta = self.beta;
-        Ok(bisect_inverse_cdf(
+        Ok(crate::utils::special_functions::newton_inverse_cdf(
             |x| regularized_incomplete_beta(alpha, beta, x),
+            |x| self.pdf(x).unwrap_or(0.0),
             p,
             0.0,
             1.0,

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -189,6 +189,15 @@ impl Distribution for Beta {
         Ok(regularized_incomplete_beta(self.beta, self.alpha, 1.0 - x))
     }
 
+    /// Gamma-ratio sampling: `X/(X+Y)` with `X ~ Γ(α)`, `Y ~ Γ(β)` —
+    /// avoids the bisection quantile entirely.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        use crate::distributions::gamma_distribution::gamma_sample_unit_rate;
+        let x = gamma_sample_unit_rate(rng, self.alpha);
+        let y = gamma_sample_unit_rate(rng, self.beta);
+        Ok(x / (x + y))
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {
             return Err(StatsError::InvalidInput {

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -195,7 +195,19 @@ impl Distribution for Beta {
         use crate::distributions::gamma_distribution::gamma_sample_unit_rate;
         let x = gamma_sample_unit_rate(rng, self.alpha);
         let y = gamma_sample_unit_rate(rng, self.beta);
-        Ok(x / (x + y))
+        let s = x + y;
+        if s == 0.0 {
+            // Both gamma draws underflowed (tiny α, β ≪ 1): in that limit
+            // the Beta concentrates at {0, 1} with P(1) = α/(α+β) — return
+            // that Bernoulli limit instead of 0/0 = NaN (numpy returns NaN).
+            use crate::distributions::normal_distribution::uniform01;
+            return Ok(if uniform01(rng) < self.alpha / (self.alpha + self.beta) {
+                1.0
+            } else {
+                0.0
+            });
+        }
+        Ok(x / s)
     }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -61,6 +61,7 @@ use crate::utils::special_functions::{bisect_inverse_cdf, ln_beta, regularized_i
 /// assert!((b.mean() - 2.0 / 7.0).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Beta {
     /// Shape parameter α > 0
     pub alpha: f64,
@@ -71,6 +72,13 @@ pub struct Beta {
 impl Beta {
     /// Creates a `Beta(α, β)` distribution. Both parameters must be positive.
     pub fn new(alpha: f64, beta: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !alpha.is_finite() || !beta.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Beta::new: parameters must be finite".to_string(),
+            });
+        }
         if alpha <= 0.0 || beta <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "Beta::new: alpha and beta must be positive".to_string(),

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -170,6 +170,16 @@ impl Distribution for Beta {
         }
         Ok(regularized_incomplete_beta(self.alpha, self.beta, x))
     }
+    /// Exact tail via the identity `1 − I_x(α, β) = I_{1−x}(β, α)`.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= 0.0 {
+            return Ok(1.0);
+        }
+        if x >= 1.0 {
+            return Ok(0.0);
+        }
+        Ok(regularized_incomplete_beta(self.beta, self.alpha, 1.0 - x))
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/distributions/binomial_distribution.rs
+++ b/src/distributions/binomial_distribution.rs
@@ -243,6 +243,43 @@ impl crate::distributions::traits::Distribution for Binomial {
                 .clamp(0.0, 1.0),
         )
     }
+    /// Direct sampling: BINV sequential inversion (mean `n·min(p,1−p)`
+    /// steps of a multiplicative recurrence) when that mean is ≤ 30,
+    /// otherwise the generic quantile search. Symmetry `k ↔ n−k` keeps
+    /// the walk on the cheap side of p.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<u64> {
+        use crate::distributions::normal_distribution::uniform01;
+        let (pp, flipped) = if self.p <= 0.5 {
+            (self.p, false)
+        } else {
+            (1.0 - self.p, true)
+        };
+        let n = self.n;
+        let k = if pp == 0.0 {
+            0
+        } else if (n as f64) * pp <= 30.0 {
+            // BINV: walk the PMF from k = 0 with the standard recurrence.
+            let q = 1.0 - pp;
+            let s = pp / q;
+            let mut f = q.powf(n as f64); // pmf(0)
+            let mut u = uniform01(rng);
+            let mut k = 0u64;
+            while u > f && k < n {
+                u -= f;
+                k += 1;
+                f *= s * ((n - k + 1) as f64) / (k as f64);
+            }
+            k
+        } else {
+            // Large n·p: exact quantile search on the flipped parameter.
+            let d = Binomial { n, p: pp };
+            crate::distributions::traits::discrete_inverse_cdf_search(uniform01(rng), |k| {
+                if k >= n { Ok(1.0) } else { d.cdf(k) }
+            })?
+        };
+        Ok(if flipped { n - k } else { k })
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
         // Bounded support: p = 1 has the finite quantile n, and the search's
         // doubling phase may probe k > n, where `cdf` errors — clamp to 1.

--- a/src/distributions/binomial_distribution.rs
+++ b/src/distributions/binomial_distribution.rs
@@ -135,7 +135,6 @@ fn cdf(k: u64, n: u64, p: f64) -> StatsResult<f64> {
     Ok(regularized_incomplete_beta((n - k) as f64, (k + 1) as f64, 1.0 - p).clamp(0.0, 1.0))
 }
 
-
 // ── Typed struct + DiscreteDistribution impl ───────────────────────────────────
 
 /// Binomial distribution Binomial(n, p) as a typed struct.
@@ -410,7 +409,11 @@ mod tests {
     fn test_binomial_pmf_large_n_no_nan() {
         // n ≈ 1030 used to overflow C(n, k) to inf in linear space,
         // producing pmf = inf·exp(−large) = NaN. Log-space keeps it finite.
-        for (n, p, k) in [(1030_u64, 0.5_f64, 515_u64), (1500, 0.3, 450), (5000, 0.5, 2500)] {
+        for (n, p, k) in [
+            (1030_u64, 0.5_f64, 515_u64),
+            (1500, 0.3, 450),
+            (5000, 0.5, 2500),
+        ] {
             let v = pmf(k, n, p).unwrap();
             assert!(v.is_finite() && v > 0.0, "pmf({k}, {n}, {p}) = {v}");
             // Consistent with the log-space trait path.
@@ -451,5 +454,4 @@ mod tests {
             StatsError::InvalidInput { .. }
         ));
     }
-
 }

--- a/src/distributions/binomial_distribution.rs
+++ b/src/distributions/binomial_distribution.rs
@@ -227,6 +227,22 @@ impl crate::distributions::traits::Distribution for Binomial {
     fn cdf(&self, k: u64) -> StatsResult<f64> {
         cdf(k, self.n, self.p)
     }
+    /// Exact tail: `S(k) = P(X ≥ k+1) = I_p(k+1, n−k)`.
+    fn sf(&self, k: u64) -> StatsResult<f64> {
+        if k >= self.n {
+            return Ok(0.0);
+        }
+        if self.p == 0.0 {
+            return Ok(0.0);
+        }
+        if self.p == 1.0 {
+            return Ok(1.0); // k < n here
+        }
+        Ok(
+            regularized_incomplete_beta((k + 1) as f64, (self.n - k) as f64, self.p)
+                .clamp(0.0, 1.0),
+        )
+    }
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
         // Bounded support: p = 1 has the finite quantile n, and the search's
         // doubling phase may probe k > n, where `cdf` errors — clamp to 1.

--- a/src/distributions/binomial_distribution.rs
+++ b/src/distributions/binomial_distribution.rs
@@ -26,7 +26,7 @@
 //! - C(n,k) is the binomial coefficient (n choose k)
 
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::ln_gamma;
+use crate::utils::special_functions::{ln_gamma, regularized_incomplete_beta};
 // Private math helpers; the public API is the [`Binomial`] struct's
 // [`DiscreteDistribution`] impl below.
 
@@ -62,17 +62,23 @@ fn pmf(k: u64, n: u64, p: f64) -> StatsResult<f64> {
             message: "binomial::pmf: p must be between 0 and 1".to_string(),
         });
     }
-    let combinations = combination(n, k)?;
+    if k > n {
+        return Err(StatsError::InvalidInput {
+            message: "binomial::pmf: k must be less than or equal to n".to_string(),
+        });
+    }
     if p == 0.0 {
-        return Ok(if k == 0 { combinations } else { 0.0 });
+        return Ok(if k == 0 { 1.0 } else { 0.0 });
     }
     if p == 1.0 {
-        return Ok(if k == n { combinations } else { 0.0 });
+        return Ok(if k == n { 1.0 } else { 0.0 });
     }
-    let k_f64 = k as f64;
-    let n_minus_k_f64 = (n - k) as f64;
-    let log_prob = k_f64 * p.ln() + n_minus_k_f64 * (1.0 - p).ln();
-    Ok(combinations * log_prob.exp())
+    // Entirely in log-space: a linear-space C(n, k) overflows f64 (→ inf,
+    // then inf·exp(…) = NaN) as soon as n ≈ 1030.
+    let log_binom =
+        ln_gamma((n + 1) as f64) - ln_gamma((k + 1) as f64) - ln_gamma((n - k + 1) as f64);
+    let log_prob = k as f64 * p.ln() + (n - k) as f64 * (1.0 - p).ln();
+    Ok((log_binom + log_prob).exp())
 }
 
 /// Cumulative distribution function (CDF) for the Binomial distribution.
@@ -112,51 +118,23 @@ fn cdf(k: u64, n: u64, p: f64) -> StatsResult<f64> {
             message: "binomial_distribution::cdf: k must be less than or equal to n".to_string(),
         });
     }
-    // Use PMF recurrence relation: P(X=i+1) = P(X=i) * (n-i)/(i+1) * p/(1-p)
-    // This avoids recomputing factorials at each step: O(k) total, O(1) per step
     if p == 0.0 {
         return Ok(1.0); // P(X <= k) = 1 when p = 0 (all mass at k=0)
     }
     if p == 1.0 {
         return Ok(if k >= n { 1.0 } else { 0.0 });
     }
-
-    // Start with pmf(0) = (1-p)^n
-    let q = 1.0 - p;
-    let mut pmf_i = q.powi(n as i32);
-    // For very large n where powi overflows, fall back to log-space
-    if pmf_i == 0.0 && n > 0 {
-        let log_pmf_0 = (n as f64) * q.ln();
-        pmf_i = log_pmf_0.exp();
+    if k == n {
+        return Ok(1.0);
     }
-    let mut cdf_sum = pmf_i;
-    let ratio = p / q;
-
-    for i in 0..k {
-        pmf_i *= ((n - i) as f64 / (i + 1) as f64) * ratio;
-        cdf_sum += pmf_i;
-    }
-
-    Ok(cdf_sum.clamp(0.0, 1.0))
+    // Closed form via the regularized incomplete beta:
+    //   P(X ≤ k) = I_{1−p}(n−k, k+1)
+    // O(1) and stable for any n. The previous O(k) PMF recurrence started at
+    // (1−p)^n, which underflows to 0 for n ≳ 1000 — the whole sum then
+    // silently collapsed to 0.
+    Ok(regularized_incomplete_beta((n - k) as f64, (k + 1) as f64, 1.0 - p).clamp(0.0, 1.0))
 }
 
-/// Calculate the binomial coefficient (n choose k).
-#[inline]
-fn combination(n: u64, k: u64) -> StatsResult<f64> {
-    if k > n {
-        return Err(StatsError::InvalidInput {
-            message: "binomial_distribution::combination: k must be less than or equal to n"
-                .to_string(),
-        });
-    }
-
-    // Use a more numerically stable algorithm
-    if k > n / 2 {
-        return combination(n, n - k);
-    }
-
-    Ok((1..=k).fold(1.0_f64, |acc, i| acc * (n - i + 1) as f64 / i as f64))
-}
 
 // ── Typed struct + DiscreteDistribution impl ───────────────────────────────────
 
@@ -250,7 +228,14 @@ impl crate::distributions::traits::Distribution for Binomial {
         cdf(k, self.n, self.p)
     }
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
-        crate::distributions::traits::discrete_inverse_cdf_search(p, |k| self.cdf(k))
+        // Bounded support: p = 1 has the finite quantile n, and the search's
+        // doubling phase may probe k > n, where `cdf` errors — clamp to 1.
+        if p == 1.0 {
+            return Ok(self.n);
+        }
+        crate::distributions::traits::discrete_inverse_cdf_search(p, |k| {
+            if k >= self.n { Ok(1.0) } else { self.cdf(k) }
+        })
     }
     fn mean(&self) -> f64 {
         self.n as f64 * self.p
@@ -405,44 +390,18 @@ mod tests {
     }
 
     #[test]
-    fn test_binomial_combination_symmetry() {
-        // Test that combination(n, k) == combination(n, n-k) when k > n/2
-        // This tests the symmetry optimization path
-        let n = 10u64;
-        let k = 8u64; // k > n/2, so should use symmetry
-
-        // Direct call should use symmetry path
-        let result1 = combination(n, k).unwrap();
-        // Should be same as combination(n, n-k)
-        let result2 = combination(n, n - k).unwrap();
-        assert_eq!(result1, result2);
-
-        // Verify it's correct: C(10, 8) = C(10, 2) = 45
-        assert_eq!(result1, 45.0);
-    }
-
-    #[test]
-    fn test_binomial_combination_k_greater_than_n() {
-        let result = combination(10, 15);
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            StatsError::InvalidInput { .. }
-        ));
-    }
-
-    #[test]
-    fn test_binomial_combination_k_equals_n() {
-        // C(n, n) = 1
-        let result = combination(10, 10).unwrap();
-        assert_eq!(result, 1.0);
-    }
-
-    #[test]
-    fn test_binomial_combination_k_zero() {
-        // C(n, 0) = 1
-        let result = combination(10, 0).unwrap();
-        assert_eq!(result, 1.0);
+    fn test_binomial_pmf_large_n_no_nan() {
+        // n ≈ 1030 used to overflow C(n, k) to inf in linear space,
+        // producing pmf = inf·exp(−large) = NaN. Log-space keeps it finite.
+        for (n, p, k) in [(1030_u64, 0.5_f64, 515_u64), (1500, 0.3, 450), (5000, 0.5, 2500)] {
+            let v = pmf(k, n, p).unwrap();
+            assert!(v.is_finite() && v > 0.0, "pmf({k}, {n}, {p}) = {v}");
+            // Consistent with the log-space trait path.
+            use crate::distributions::traits::Distribution;
+            let d = Binomial::new(n, p).unwrap();
+            let via_log = d.logpdf(k).unwrap().exp();
+            assert!((v - via_log).abs() <= 1e-12 * via_log);
+        }
     }
 
     #[test]
@@ -476,25 +435,4 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_binomial_combination_k_exactly_n_over_2() {
-        // Test boundary case: k = n/2 (should not use symmetry)
-        let n = 10u64;
-        let k = 5u64; // k = n/2, should not use symmetry
-        let result = combination(n, k).unwrap();
-        // C(10, 5) = 252
-        assert_eq!(result, 252.0);
-    }
-
-    #[test]
-    fn test_binomial_combination_k_just_over_n_over_2() {
-        // Test k = n/2 + 1 (should use symmetry)
-        let n = 10u64;
-        let k = 6u64; // k > n/2, should use symmetry
-        let result1 = combination(n, k).unwrap();
-        let result2 = combination(n, n - k).unwrap();
-        assert_eq!(result1, result2);
-        // C(10, 6) = C(10, 4) = 210
-        assert_eq!(result1, 210.0);
-    }
 }

--- a/src/distributions/binomial_distribution.rs
+++ b/src/distributions/binomial_distribution.rs
@@ -149,6 +149,7 @@ fn cdf(k: u64, n: u64, p: f64) -> StatsResult<f64> {
 /// assert!((b.mean() - 5.0).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Binomial {
     /// Number of trials n (must be ≥ 1)
     pub n: u64,

--- a/src/distributions/cauchy.rs
+++ b/src/distributions/cauchy.rs
@@ -1,0 +1,313 @@
+//! # Cauchy Distribution
+//!
+//! The Cauchy(x₀, γ) distribution (also known as the Lorentz distribution) is a
+//! heavy-tailed continuous distribution. It arises as the ratio of two
+//! independent standard normal variables and describes resonance line shapes
+//! in physics.
+//!
+//! **PDF**: f(x; x₀, γ) = 1 / (πγ · [1 + ((x − x₀)/γ)²])
+//!
+//! **CDF**: F(x) = 1/2 + arctan((x − x₀)/γ) / π  (closed-form, invertible)
+//!
+//! **Mean / Variance**: *undefined* — the tails are so heavy that no moment of
+//! order ≥ 1 exists. [`Distribution::mean`] and [`Distribution::variance`]
+//! return `f64::NAN` for this distribution.
+//!
+//! ## Applications
+//!
+//! - Spectroscopy (Lorentzian line profiles)
+//! - Robust statistics benchmarks (sample mean never converges)
+//! - Modeling extreme financial returns
+//!
+//! ## Example
+//!
+//! ```rust
+//! use rs_stats::distributions::cauchy::Cauchy;
+//! use rs_stats::distributions::traits::Distribution;
+//!
+//! let c = Cauchy::new(0.0, 1.0).unwrap(); // standard Cauchy
+//! assert!((c.cdf(0.0).unwrap() - 0.5).abs() < 1e-15);
+//! assert!((c.inverse_cdf(0.75).unwrap() - 1.0).abs() < 1e-12);
+//! assert!(c.mean().is_nan()); // undefined
+//! ```
+
+use crate::distributions::traits::Distribution;
+use crate::error::{StatsError, StatsResult};
+use std::f64::consts::PI;
+
+/// Cauchy distribution Cauchy(x₀, γ).
+///
+/// # Examples
+/// ```
+/// use rs_stats::distributions::cauchy::Cauchy;
+/// use rs_stats::distributions::traits::Distribution;
+///
+/// let c = Cauchy::new(2.0, 1.5).unwrap();
+/// assert!((c.inverse_cdf(0.5).unwrap() - 2.0).abs() < 1e-15); // median = x₀
+/// ```
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Cauchy {
+    /// Location parameter x₀ (median and mode)
+    pub x0: f64,
+    /// Scale parameter γ > 0 (half-width at half-maximum)
+    pub gamma: f64,
+}
+
+impl Cauchy {
+    /// Creates a `Cauchy(x₀, γ)` distribution.
+    pub fn new(x0: f64, gamma: f64) -> StatsResult<Self> {
+        if !x0.is_finite() || !gamma.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Cauchy::new: parameters must be finite".to_string(),
+            });
+        }
+        if gamma <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Cauchy::new: gamma must be positive".to_string(),
+            });
+        }
+        Ok(Self { x0, gamma })
+    }
+
+    /// Robust fitting: sample median for x₀ and half the interquartile
+    /// range (IQR / 2) for γ.
+    ///
+    /// MLE has no closed form for the Cauchy, and moment estimators do not
+    /// exist (the distribution has no mean). The median and IQR/2 are the
+    /// standard consistent quantile estimators: for a Cauchy the theoretical
+    /// quartiles are x₀ ± γ, so (Q₃ − Q₁)/2 = γ.
+    pub fn fit(data: &[f64]) -> StatsResult<Self> {
+        if data.is_empty() {
+            return Err(StatsError::InvalidInput {
+                message: "Cauchy::fit: data must not be empty".to_string(),
+            });
+        }
+        let mut sorted = data.to_vec();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let x0 = quantile_sorted(&sorted, 0.5);
+        let gamma = (quantile_sorted(&sorted, 0.75) - quantile_sorted(&sorted, 0.25)) / 2.0;
+        if gamma <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Cauchy::fit: data has zero interquartile range".to_string(),
+            });
+        }
+        Self::new(x0, gamma)
+    }
+}
+
+/// Linear-interpolation quantile on pre-sorted data (numpy default method).
+fn quantile_sorted(sorted: &[f64], q: f64) -> f64 {
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0];
+    }
+    let h = (n - 1) as f64 * q;
+    let lo = h.floor() as usize;
+    let hi = (lo + 1).min(n - 1);
+    let frac = h - lo as f64;
+    sorted[lo] + frac * (sorted[hi] - sorted[lo])
+}
+
+impl Distribution for Cauchy {
+    type X = f64;
+    fn name(&self) -> &str {
+        "Cauchy"
+    }
+    fn num_params(&self) -> usize {
+        2
+    }
+
+    fn pdf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.x0) / self.gamma;
+        Ok(1.0 / (PI * self.gamma * (1.0 + z * z)))
+    }
+
+    fn logpdf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.x0) / self.gamma;
+        // ln_1p(z²) keeps precision for |z| ≪ 1 where 1 + z² rounds to 1.
+        Ok(-(PI * self.gamma).ln() - (z * z).ln_1p())
+    }
+
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // ln(πγ) hoisted out of the per-point loop (one ln_1p per point remains).
+        let log_norm = -(PI * self.gamma).ln();
+        let inv_gamma = 1.0 / self.gamma;
+        let mut acc = 0.0_f64;
+        for &x in data {
+            let z = (x - self.x0) * inv_gamma;
+            acc -= (z * z).ln_1p();
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
+    fn cdf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.x0) / self.gamma;
+        // Left tail via the identity 1/2 + atan(z)/π = atan(−1/z)/π for
+        // z < 0: avoids the catastrophic cancellation of 0.5 − (≈0.5).
+        Ok(if z < 0.0 {
+            (-1.0 / z).atan() / PI
+        } else {
+            0.5 + z.atan() / PI
+        })
+    }
+
+    /// Exact tail: `S(x) = atan(γ/(x − x₀))/π` for `x > x₀` — full relative
+    /// precision deep into the right tail (no `0.5 − 0.5` cancellation).
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.x0) / self.gamma;
+        Ok(if z > 0.0 {
+            (1.0 / z).atan() / PI
+        } else {
+            0.5 - z.atan() / PI
+        })
+    }
+
+    fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
+        if !(0.0..=1.0).contains(&p) {
+            return Err(StatsError::InvalidInput {
+                message: "Cauchy::inverse_cdf: p must be in [0, 1]".to_string(),
+            });
+        }
+        if p == 0.0 {
+            return Ok(f64::NEG_INFINITY);
+        }
+        if p == 1.0 {
+            return Ok(f64::INFINITY);
+        }
+        // Closed form x₀ + γ·tan(π(p − ½)), evaluated per branch through the
+        // cotangent identity tan(π(p − ½)) = −1/tan(πp): computing p − ½
+        // directly would drop p's low bits for p → 0 and p → 1.
+        Ok(if p == 0.5 {
+            self.x0
+        } else if p < 0.5 {
+            self.x0 - self.gamma / (PI * p).tan()
+        } else {
+            // 1 − p is exact for p ∈ [0.5, 1] (Sterbenz lemma).
+            self.x0 + self.gamma / (PI * (1.0 - p)).tan()
+        })
+    }
+
+    /// The Cauchy distribution has **no mean** (the defining integral
+    /// diverges); returns `f64::NAN`.
+    fn mean(&self) -> f64 {
+        f64::NAN
+    }
+
+    /// The Cauchy distribution has **no variance** (no moments of order ≥ 1
+    /// exist); returns `f64::NAN`.
+    fn variance(&self) -> f64 {
+        f64::NAN
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.cauchy(loc=2, scale=1.5).
+    const TOL: f64 = 1e-12;
+
+    #[test]
+    fn test_cauchy_pdf_vs_scipy() {
+        let c = Cauchy::new(2.0, 1.5).unwrap();
+        assert!((c.pdf(4.0).unwrap() - 0.07639437268410977).abs() < TOL);
+        assert!((c.logpdf(4.0).unwrap() - (-2.5718462414895455)).abs() < TOL);
+        // Mode: pdf(x0) = 1/(πγ)
+        assert!((c.pdf(2.0).unwrap() - 1.0 / (PI * 1.5)).abs() < TOL);
+    }
+
+    #[test]
+    fn test_cauchy_cdf_sf_vs_scipy() {
+        let c = Cauchy::new(2.0, 1.5).unwrap();
+        assert!((c.cdf(4.0).unwrap() - 0.7951672353008665).abs() < TOL);
+        assert!((c.sf(4.0).unwrap() - 0.20483276469913345).abs() < TOL);
+        assert!((c.cdf(-1.0).unwrap() - 0.14758361765043326).abs() < TOL);
+        assert!((c.cdf(2.0).unwrap() - 0.5).abs() < TOL);
+    }
+
+    #[test]
+    fn test_cauchy_deep_tail_sf() {
+        let c = Cauchy::new(2.0, 1.5).unwrap();
+        // scipy: cauchy(2, 1.5).sf(1e6) = 4.774657842068963e-07
+        let s = c.sf(1e6).unwrap();
+        assert!(
+            (s - 4.774657842068963e-07).abs() < 1e-19 * 1e12, // relative ~1e-12
+            "sf(1e6) = {s}"
+        );
+        assert!((s / 4.774657842068963e-07 - 1.0).abs() < 1e-12);
+        // Symmetric left tail via cdf
+        let l = c.cdf(-1e6).unwrap();
+        assert!(l > 0.0 && l < 1e-6);
+    }
+
+    #[test]
+    fn test_cauchy_inverse_cdf_vs_scipy() {
+        let c = Cauchy::new(2.0, 1.5).unwrap();
+        assert!((c.inverse_cdf(0.3).unwrap() - 0.9101862079919583).abs() < TOL);
+        assert!((c.inverse_cdf(0.9).unwrap() - 6.616525305762882).abs() < TOL);
+        assert!((c.inverse_cdf(0.5).unwrap() - 2.0).abs() < TOL);
+        assert_eq!(c.inverse_cdf(0.0).unwrap(), f64::NEG_INFINITY);
+        assert_eq!(c.inverse_cdf(1.0).unwrap(), f64::INFINITY);
+        assert!(c.inverse_cdf(-0.1).is_err());
+        assert!(c.inverse_cdf(1.1).is_err());
+    }
+
+    #[test]
+    fn test_cauchy_roundtrip() {
+        let c = Cauchy::new(-3.0, 0.7).unwrap();
+        for &x in &[-10.0, -3.5, -3.0, -2.9, 0.0, 5.0, 100.0] {
+            let p = c.cdf(x).unwrap();
+            let x_back = c.inverse_cdf(p).unwrap();
+            assert!((x - x_back).abs() < 1e-9 * x.abs().max(1.0), "x={x}");
+        }
+        for &p in &[1e-10, 0.01, 0.3, 0.5, 0.7, 0.99, 1.0 - 1e-10] {
+            let x = c.inverse_cdf(p).unwrap();
+            let p_back = c.cdf(x).unwrap();
+            assert!((p - p_back).abs() < 1e-12 * p.max(1e-3), "p={p}");
+        }
+    }
+
+    #[test]
+    fn test_cauchy_moments_undefined() {
+        let c = Cauchy::new(2.0, 1.5).unwrap();
+        assert!(c.mean().is_nan());
+        assert!(c.variance().is_nan());
+        assert!(c.std_dev().is_nan());
+    }
+
+    #[test]
+    fn test_cauchy_fit_quantile_estimators() {
+        // Odd-length data with known median / quartiles.
+        let data = vec![-4.0, -1.0, 0.0, 1.0, 4.0];
+        let c = Cauchy::fit(&data).unwrap();
+        assert!((c.x0 - 0.0).abs() < 1e-12);
+        // Q1 = -1, Q3 = 1 → gamma = 1
+        assert!((c.gamma - 1.0).abs() < 1e-12);
+        // Constant data: zero IQR → error
+        assert!(Cauchy::fit(&[3.0; 8]).is_err());
+        assert!(Cauchy::fit(&[]).is_err());
+    }
+
+    #[test]
+    fn test_cauchy_log_likelihood_fast_matches_logpdf_sum() {
+        let c = Cauchy::new(1.0, 2.0).unwrap();
+        let data = vec![-5.0, -0.5, 1.0, 2.5, 40.0];
+        let expected: f64 = data.iter().map(|&x| c.logpdf(x).unwrap()).sum();
+        assert!((c.log_likelihood_fast(&data) - expected).abs() < 1e-10);
+        assert!((c.log_likelihood(&data).unwrap() - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cauchy_invalid_params() {
+        assert!(Cauchy::new(f64::NAN, 1.0).is_err());
+        assert!(Cauchy::new(0.0, f64::NAN).is_err());
+        assert!(Cauchy::new(f64::INFINITY, 1.0).is_err());
+        assert!(Cauchy::new(0.0, 0.0).is_err());
+        assert!(Cauchy::new(0.0, -1.5).is_err());
+    }
+}

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -130,6 +130,12 @@ impl Distribution for ChiSquared {
         )
     }
 
+    /// χ²(k) = 2·Γ(k/2, rate = 1): one Marsaglia-Tsang draw.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        use crate::distributions::gamma_distribution::gamma_sample_unit_rate;
+        Ok(2.0 * gamma_sample_unit_rate(rng, self.k / 2.0))
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {
             return Err(StatsError::InvalidInput {

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -79,7 +79,26 @@ impl Distribution for ChiSquared {
             return Ok(f64::NEG_INFINITY);
         }
         let k = self.k;
-        Ok((k / 2.0 - 1.0) * x.ln() - x / 2.0 - (k / 2.0) * 2_f64.ln() - ln_gamma(k / 2.0))
+        Ok((k / 2.0 - 1.0) * x.ln() - x / 2.0 - (k / 2.0) * std::f64::consts::LN_2
+            - ln_gamma(k / 2.0))
+    }
+
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // (k/2)·ln 2 + ln Γ(k/2) hoisted out of the per-point loop.
+        let half_k = self.k / 2.0;
+        let log_norm = -half_k * std::f64::consts::LN_2 - ln_gamma(half_k);
+        let mut acc = 0.0_f64;
+        for &x in data {
+            if x <= 0.0 {
+                return f64::NEG_INFINITY;
+            }
+            acc += (half_k - 1.0) * x.ln() - x / 2.0;
+        }
+        data.len() as f64 * log_norm + acc
     }
 
     fn cdf(&self, x: f64) -> StatsResult<f64> {

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -23,6 +23,7 @@ use crate::utils::special_functions::{bisect_inverse_cdf, ln_gamma, regularized_
 /// assert_eq!(c.variance(), 8.0);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChiSquared {
     /// Degrees of freedom k > 0
     pub k: f64,
@@ -31,6 +32,13 @@ pub struct ChiSquared {
 impl ChiSquared {
     /// Creates a `χ²(k)` distribution.
     pub fn new(k: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !k.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "ChiSquared::new: parameters must be finite".to_string(),
+            });
+        }
         if k <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "ChiSquared::new: k must be positive".to_string(),

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -87,7 +87,9 @@ impl Distribution for ChiSquared {
             return Ok(f64::NEG_INFINITY);
         }
         let k = self.k;
-        Ok((k / 2.0 - 1.0) * x.ln() - x / 2.0 - (k / 2.0) * std::f64::consts::LN_2
+        Ok((k / 2.0 - 1.0) * x.ln()
+            - x / 2.0
+            - (k / 2.0) * std::f64::consts::LN_2
             - ln_gamma(k / 2.0))
     }
 
@@ -120,10 +122,12 @@ impl Distribution for ChiSquared {
         if x <= 0.0 {
             return Ok(1.0);
         }
-        Ok(crate::utils::special_functions::regularized_incomplete_gamma_upper(
-            self.k / 2.0,
-            x / 2.0,
-        ))
+        Ok(
+            crate::utils::special_functions::regularized_incomplete_gamma_upper(
+                self.k / 2.0,
+                x / 2.0,
+            ),
+        )
     }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -9,7 +9,7 @@
 
 use crate::distributions::traits::Distribution;
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::{bisect_inverse_cdf, ln_gamma, regularized_incomplete_gamma};
+use crate::utils::special_functions::{ln_gamma, regularized_incomplete_gamma};
 
 /// Chi-squared distribution χ²(k).
 ///
@@ -150,8 +150,9 @@ impl Distribution for ChiSquared {
         }
         let k = self.k;
         let hi = k + 10.0 * (2.0 * k).sqrt() + 50.0;
-        Ok(bisect_inverse_cdf(
+        Ok(crate::utils::special_functions::newton_inverse_cdf(
             |x| regularized_incomplete_gamma(k / 2.0, x / 2.0),
+            |x| self.pdf(x).unwrap_or(0.0),
             p,
             0.0,
             hi,

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -107,6 +107,16 @@ impl Distribution for ChiSquared {
         }
         Ok(regularized_incomplete_gamma(self.k / 2.0, x / 2.0))
     }
+    /// Exact tail: `S(x) = Q(k/2, x/2)` (upper regularized incomplete gamma).
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= 0.0 {
+            return Ok(1.0);
+        }
+        Ok(crate::utils::special_functions::regularized_incomplete_gamma_upper(
+            self.k / 2.0,
+            x / 2.0,
+        ))
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/distributions/chi_squared.rs
+++ b/src/distributions/chi_squared.rs
@@ -33,7 +33,7 @@ impl ChiSquared {
     /// Creates a `χ²(k)` distribution.
     pub fn new(k: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !k.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "ChiSquared::new: parameters must be finite".to_string(),

--- a/src/distributions/exponential_distribution.rs
+++ b/src/distributions/exponential_distribution.rs
@@ -49,10 +49,12 @@ use crate::error::{StatsError, StatsResult};
 ///
 #[inline]
 fn exponential_pdf(x: f64, lambda: f64) -> StatsResult<f64> {
+    // Out-of-support x returns 0 density (like every other continuous
+    // distribution here) — pre-v3.1 this was an error, which made
+    // Exponential the only candidate to abort fit_all's log_likelihood
+    // on a single negative point.
     if x < 0.0 {
-        return Err(StatsError::InvalidInput {
-            message: "exponential_pdf: x must be non-negative".to_string(),
-        });
+        return Ok(0.0);
     }
     if lambda <= 0.0 {
         return Err(StatsError::InvalidInput {
@@ -86,10 +88,10 @@ fn exponential_pdf(x: f64, lambda: f64) -> StatsResult<f64> {
 ///
 #[inline]
 fn exponential_cdf(x: f64, lambda: f64) -> StatsResult<f64> {
+    // Out-of-support: F(x) = 0 for x < 0 (aligned with the other
+    // continuous distributions; was an error before v3.1).
     if x < 0.0 {
-        return Err(StatsError::InvalidInput {
-            message: "exponential_cdf: x must be non-negative".to_string(),
-        });
+        return Ok(0.0);
     }
     if lambda <= 0.0 {
         return Err(StatsError::InvalidInput {
@@ -180,6 +182,7 @@ fn exponential_inverse_cdf(p: f64, lambda: f64) -> StatsResult<f64> {
 /// assert!((e.mean() - 0.5).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Exponential {
     /// Rate parameter λ > 0
     pub lambda: f64,
@@ -188,6 +191,13 @@ pub struct Exponential {
 impl Exponential {
     /// Creates an `Exponential` distribution with validation.
     pub fn new(lambda: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !lambda.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Exponential::new: parameters must be finite".to_string(),
+            });
+        }
         if lambda <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "Exponential::new: lambda must be positive".to_string(),
@@ -226,9 +236,7 @@ impl crate::distributions::traits::Distribution for Exponential {
     }
     fn logpdf(&self, x: f64) -> StatsResult<f64> {
         if x < 0.0 {
-            return Err(StatsError::InvalidInput {
-                message: "Exponential::logpdf: x must be non-negative".to_string(),
-            });
+            return Ok(f64::NEG_INFINITY);
         }
         Ok(self.lambda.ln() - self.lambda * x)
     }
@@ -238,8 +246,7 @@ impl crate::distributions::traits::Distribution for Exponential {
     /// Exact tail: `S(x) = exp(−λx)`.
     fn sf(&self, x: f64) -> StatsResult<f64> {
         if x < 0.0 {
-            // Same domain handling as cdf (error for negative x).
-            return self.cdf(x).map(|c| 1.0 - c);
+            return Ok(1.0);
         }
         Ok((-self.lambda * x).exp())
     }
@@ -339,15 +346,10 @@ mod tests {
     }
 
     #[test]
-    fn test_exponential_pdf_invalid_x() {
-        let result = exponential_pdf(-1.0, 2.0);
-        assert!(result.is_err());
-        match result {
-            Err(StatsError::InvalidInput { message }) => {
-                assert!(message.contains("x must be non-negative"));
-            }
-            _ => panic!("Expected InvalidInput error"),
-        }
+    fn test_exponential_pdf_out_of_support() {
+        // x < 0 is out of support: density 0 (aligned with the other
+        // continuous distributions), no longer an error.
+        assert_eq!(exponential_pdf(-1.0, 2.0).unwrap(), 0.0);
     }
 
     #[test]
@@ -381,13 +383,8 @@ mod tests {
     }
 
     #[test]
-    fn test_exponential_cdf_invalid_x() {
-        let result = exponential_cdf(-1.0, 2.0);
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            StatsError::InvalidInput { .. }
-        ));
+    fn test_exponential_cdf_out_of_support() {
+        assert_eq!(exponential_cdf(-1.0, 2.0).unwrap(), 0.0);
     }
 
     #[test]

--- a/src/distributions/exponential_distribution.rs
+++ b/src/distributions/exponential_distribution.rs
@@ -50,7 +50,7 @@ use crate::error::{StatsError, StatsResult};
 #[inline]
 fn exponential_pdf(x: f64, lambda: f64) -> StatsResult<f64> {
     // Out-of-support x returns 0 density (like every other continuous
-    // distribution here) — pre-v3.1 this was an error, which made
+    // distribution here) — pre-v4.0 this was an error, which made
     // Exponential the only candidate to abort fit_all's log_likelihood
     // on a single negative point.
     if x < 0.0 {
@@ -89,7 +89,7 @@ fn exponential_pdf(x: f64, lambda: f64) -> StatsResult<f64> {
 #[inline]
 fn exponential_cdf(x: f64, lambda: f64) -> StatsResult<f64> {
     // Out-of-support: F(x) = 0 for x < 0 (aligned with the other
-    // continuous distributions; was an error before v3.1).
+    // continuous distributions; was an error before v4.0).
     if x < 0.0 {
         return Ok(0.0);
     }
@@ -192,7 +192,7 @@ impl Exponential {
     /// Creates an `Exponential` distribution with validation.
     pub fn new(lambda: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !lambda.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Exponential::new: parameters must be finite".to_string(),

--- a/src/distributions/exponential_distribution.rs
+++ b/src/distributions/exponential_distribution.rs
@@ -235,6 +235,14 @@ impl crate::distributions::traits::Distribution for Exponential {
     fn cdf(&self, x: f64) -> StatsResult<f64> {
         exponential_cdf(x, self.lambda)
     }
+    /// Exact tail: `S(x) = exp(−λx)`.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x < 0.0 {
+            // Same domain handling as cdf (error for negative x).
+            return self.cdf(x).map(|c| 1.0 - c);
+        }
+        Ok((-self.lambda * x).exp())
+    }
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         exponential_inverse_cdf(p, self.lambda)
     }

--- a/src/distributions/exponential_distribution.rs
+++ b/src/distributions/exponential_distribution.rs
@@ -96,7 +96,9 @@ fn exponential_cdf(x: f64, lambda: f64) -> StatsResult<f64> {
             message: "exponential_cdf: lambda must be positive".to_string(),
         });
     }
-    Ok(1.0 - (-lambda * x).exp())
+    // −expm1(−λx) instead of 1 − exp(−λx): keeps full relative precision
+    // for λx ≪ 1, where the subtraction cancels catastrophically.
+    Ok(-(-lambda * x).exp_m1())
 }
 
 /// Inverse cumulative distribution function for the Exponential distribution.
@@ -128,7 +130,9 @@ fn exponential_inverse_cdf(p: f64, lambda: f64) -> StatsResult<f64> {
             message: "exponential_inverse_cdf: lambda must be positive".to_string(),
         });
     }
-    Ok(-((1.0 - p).ln()) / lambda)
+    // −ln_1p(−p) instead of −ln(1 − p): for small p, `1.0 − p` rounds away
+    // p's low bits before the log ever sees them.
+    Ok(-(-p).ln_1p() / lambda)
 }
 
 /// Mean (expected value) of the Exponential distribution.

--- a/src/distributions/f_distribution.rs
+++ b/src/distributions/f_distribution.rs
@@ -114,6 +114,24 @@ impl Distribution for FDistribution {
         Ok(log_pdf)
     }
 
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // 0.5·d2·ln d2 − ln B(d1/2, d2/2) hoisted out of the per-point loop.
+        let (d1, d2) = (self.d1, self.d2);
+        let log_norm = 0.5 * d2 * d2.ln() - ln_beta(d1 / 2.0, d2 / 2.0);
+        let mut acc = 0.0_f64;
+        for &x in data {
+            if x <= 0.0 {
+                return f64::NEG_INFINITY;
+            }
+            acc += 0.5 * (d1 * (d1 * x).ln() - (d1 + d2) * (d1 * x + d2).ln()) - x.ln();
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
     fn cdf(&self, x: f64) -> StatsResult<f64> {
         if x <= 0.0 {
             return Ok(0.0);

--- a/src/distributions/f_distribution.rs
+++ b/src/distributions/f_distribution.rs
@@ -22,6 +22,7 @@ use crate::utils::special_functions::{bisect_inverse_cdf, ln_beta, regularized_i
 /// assert!((f.mean() - 10.0 / 8.0).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FDistribution {
     /// Numerator degrees of freedom d1 > 0
     pub d1: f64,
@@ -32,6 +33,13 @@ pub struct FDistribution {
 impl FDistribution {
     /// Creates an `F(d1, d2)` distribution.
     pub fn new(d1: f64, d2: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !d1.is_finite() || !d2.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "FDistribution::new: parameters must be finite".to_string(),
+            });
+        }
         if d1 <= 0.0 || d2 <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "FDistribution::new: d1 and d2 must be positive".to_string(),

--- a/src/distributions/f_distribution.rs
+++ b/src/distributions/f_distribution.rs
@@ -9,7 +9,7 @@
 
 use crate::distributions::traits::Distribution;
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::{bisect_inverse_cdf, ln_beta, regularized_incomplete_beta};
+use crate::utils::special_functions::{ln_beta, regularized_incomplete_beta};
 
 /// F-distribution F(d1, d2).
 ///
@@ -182,7 +182,7 @@ impl Distribution for FDistribution {
         let d2 = self.d2;
         let mean = if d2 > 2.0 { d2 / (d2 - 2.0) } else { 5.0 };
         let hi = mean * 20.0;
-        Ok(bisect_inverse_cdf(
+        Ok(crate::utils::special_functions::newton_inverse_cdf(
             |x| {
                 if x <= 0.0 {
                     return 0.0;
@@ -190,6 +190,7 @@ impl Distribution for FDistribution {
                 let t = d1 * x / (d1 * x + d2);
                 regularized_incomplete_beta(d1 / 2.0, d2 / 2.0, t)
             },
+            |x| self.pdf(x).unwrap_or(0.0),
             p,
             0.0,
             hi,

--- a/src/distributions/f_distribution.rs
+++ b/src/distributions/f_distribution.rs
@@ -140,6 +140,14 @@ impl Distribution for FDistribution {
         let t = self.d1 * x / (self.d1 * x + self.d2);
         Ok(regularized_incomplete_beta(self.d1 / 2.0, self.d2 / 2.0, t))
     }
+    /// Exact tail: `S(x) = I_{d2/(d1·x + d2)}(d2/2, d1/2)`.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= 0.0 {
+            return Ok(1.0);
+        }
+        let t = self.d2 / (self.d1 * x + self.d2);
+        Ok(regularized_incomplete_beta(self.d2 / 2.0, self.d1 / 2.0, t))
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/distributions/f_distribution.rs
+++ b/src/distributions/f_distribution.rs
@@ -34,7 +34,7 @@ impl FDistribution {
     /// Creates an `F(d1, d2)` distribution.
     pub fn new(d1: f64, d2: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !d1.is_finite() || !d2.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "FDistribution::new: parameters must be finite".to_string(),

--- a/src/distributions/f_distribution.rs
+++ b/src/distributions/f_distribution.rs
@@ -157,6 +157,15 @@ impl Distribution for FDistribution {
         Ok(regularized_incomplete_beta(self.d2 / 2.0, self.d1 / 2.0, t))
     }
 
+    /// `F = (X/d₁)/(Y/d₂)` with `X ~ χ²(d₁)`, `Y ~ χ²(d₂)` via
+    /// Marsaglia-Tsang gamma draws.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        use crate::distributions::gamma_distribution::gamma_sample_unit_rate;
+        let x = 2.0 * gamma_sample_unit_rate(rng, self.d1 / 2.0);
+        let y = 2.0 * gamma_sample_unit_rate(rng, self.d2 / 2.0);
+        Ok((x / self.d1) / (y / self.d2))
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {
             return Err(StatsError::InvalidInput {

--- a/src/distributions/fitting.rs
+++ b/src/distributions/fitting.rs
@@ -13,7 +13,7 @@
 //! | Function | Description |
 //! |----------|-------------|
 //! | `auto_fit(data)` | Auto-detect type + return single best fit |
-//! | `fit_all(data)` | All 10 continuous distributions, ranked by AIC |
+//! | `fit_all(data)` | All 14 continuous distributions, ranked by AIC |
 //! | `fit_best(data)` | Best continuous distribution (lowest AIC) |
 //! | `fit_all_discrete(data)` | All 4 discrete distributions, ranked by AIC |
 //! | `fit_best_discrete(data)` | Best discrete distribution |
@@ -61,13 +61,17 @@
 use crate::distributions::{
     beta::Beta,
     binomial_distribution::Binomial,
+    cauchy::Cauchy,
     chi_squared::ChiSquared,
     f_distribution::FDistribution,
     gamma_distribution::Gamma,
     geometric::Geometric,
+    laplace::Laplace,
+    logistic::Logistic,
     lognormal::LogNormal,
     negative_binomial::NegativeBinomial,
     normal_distribution::Normal,
+    pareto::Pareto,
     poisson_distribution::Poisson,
     student_t::StudentT,
     traits::{DiscreteDistribution, Distribution},
@@ -328,6 +332,10 @@ const CONTINUOUS_FITTERS: &[ContinuousFitter] = &[
             .ok()
             .and_then(|x| try_fit_continuous(s, x))
     },
+    |d, s| Cauchy::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| Laplace::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| Pareto::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| Logistic::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
 ];
 
 /// Fit all continuous distributions to `data` and return ranked results (by AIC).
@@ -457,6 +465,10 @@ const CONTINUOUS_VERBOSE_FITTERS: &[ContinuousVerboseFitter] = &[
     |d, s| try_fit_verbose("StudentT", s, StudentT::fit(d)),
     |d, s| try_fit_verbose("FDistribution", s, FDistribution::fit(d)),
     |d, s| try_fit_verbose("ChiSquared", s, ChiSquared::fit(d)),
+    |d, s| try_fit_verbose("Cauchy", s, Cauchy::fit(d)),
+    |d, s| try_fit_verbose("Laplace", s, Laplace::fit(d)),
+    |d, s| try_fit_verbose("Pareto", s, Pareto::fit(d)),
+    |d, s| try_fit_verbose("Logistic", s, Logistic::fit(d)),
 ];
 
 pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<SkippedFit>)> {

--- a/src/distributions/fitting.rs
+++ b/src/distributions/fitting.rs
@@ -136,18 +136,24 @@ pub fn ks_test(data: &[f64], cdf: impl Fn(f64) -> f64) -> KsResult {
 /// evaluations: see [`fit_all`] which fits 10 candidates from a single
 /// `&[f64]` input.
 pub fn ks_test_with_scratch(scratch: &mut [f64], cdf: impl Fn(f64) -> f64) -> KsResult {
-    let n = scratch.len();
+    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    ks_test_presorted(scratch, cdf)
+}
+
+/// KS test on data that is **already sorted ascending** — skips both the
+/// allocation and the O(n log n) sort. This is what [`fit_all`] uses: the
+/// data is sorted once and shared read-only across all candidates.
+pub fn ks_test_presorted(sorted: &[f64], cdf: impl Fn(f64) -> f64) -> KsResult {
+    let n = sorted.len();
     if n == 0 {
         return KsResult {
             statistic: 0.0,
             p_value: 1.0,
         };
     }
-    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-
     let nf = n as f64;
     let mut d = 0.0_f64;
-    for (i, &x) in scratch.iter().enumerate() {
+    for (i, &x) in sorted.iter().enumerate() {
         let f = cdf(x);
         let upper = (i + 1) as f64 / nf;
         let lower = i as f64 / nf;
@@ -171,18 +177,22 @@ pub fn ks_test_discrete(data: &[f64], cdf: impl Fn(u64) -> f64) -> KsResult {
 
 /// Zero-allocation variant of [`ks_test_discrete`].
 pub fn ks_test_discrete_with_scratch(scratch: &mut [f64], cdf: impl Fn(u64) -> f64) -> KsResult {
-    let n = scratch.len();
+    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    ks_test_discrete_presorted(scratch, cdf)
+}
+
+/// Discrete KS test on data that is **already sorted ascending**.
+pub fn ks_test_discrete_presorted(sorted: &[f64], cdf: impl Fn(u64) -> f64) -> KsResult {
+    let n = sorted.len();
     if n == 0 {
         return KsResult {
             statistic: 0.0,
             p_value: 1.0,
         };
     }
-    scratch.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-
     let nf = n as f64;
     let mut d = 0.0_f64;
-    for (i, &x) in scratch.iter().enumerate() {
+    for (i, &x) in sorted.iter().enumerate() {
         let k = x.round() as u64;
         let f = cdf(k);
         let upper = (i + 1) as f64 / nf;
@@ -238,13 +248,45 @@ pub struct FitResult {
 
 // ── Continuous fitting ─────────────────────────────────────────────────────────
 
+/// Below this many data points the rayon dispatch overhead (task setup +
+/// pool wake-up) exceeds the cost of fitting all candidates sequentially.
+const PAR_THRESHOLD: usize = 1000;
+
+/// Compute AIC and BIC from a **single** log-likelihood pass.
+///
+/// `aic()` and `bic()` each walk the whole dataset; fit_all used to call
+/// both, doubling the dominant cost of every candidate.
+fn ll_diagnostics<D: Distribution<X = f64>>(dist: &D, data: &[f64]) -> Option<(f64, f64)>
+where
+    D::X: Copy,
+{
+    let ll = dist.log_likelihood(data).ok().filter(|x| x.is_finite())?;
+    let k = dist.num_params() as f64;
+    let n = data.len() as f64;
+    let aic = 2.0 * k - 2.0 * ll;
+    let bic = k * n.ln() - 2.0 * ll;
+    (aic.is_finite() && bic.is_finite()).then_some((aic, bic))
+}
+
+fn ll_diagnostics_discrete<D: Distribution<X = u64>>(dist: &D, data: &[u64]) -> Option<(f64, f64)> {
+    let ll = dist.log_likelihood(data).ok().filter(|x| x.is_finite())?;
+    let k = dist.num_params() as f64;
+    let n = data.len() as f64;
+    let aic = 2.0 * k - 2.0 * ll;
+    let bic = k * n.ln() - 2.0 * ll;
+    (aic.is_finite() && bic.is_finite()).then_some((aic, bic))
+}
+
 /// Apply [`Distribution`]-level diagnostics (AIC / BIC / KS) to one fitted
 /// distribution, producing a [`FitResult`]. Returns `None` if any of the
-/// diagnostics fails (non-finite AIC/BIC or fit error).
-fn try_fit_continuous<D: Distribution<X = f64>>(data: &[f64], dist: D) -> Option<FitResult> {
-    let aic = dist.aic(data).ok().filter(|x| x.is_finite())?;
-    let bic = dist.bic(data).ok().filter(|x| x.is_finite())?;
-    let ks = ks_test(data, |x| dist.cdf(x).unwrap_or(0.0));
+/// diagnostics fails (non-finite log-likelihood or fit error).
+/// `sorted` must be `data` sorted ascending (shared across candidates).
+fn try_fit_continuous<D: Distribution<X = f64>>(
+    sorted: &[f64],
+    dist: D,
+) -> Option<FitResult> {
+    let (aic, bic) = ll_diagnostics(&dist, sorted)?;
+    let ks = ks_test_presorted(sorted, |x| dist.cdf(x).unwrap_or(0.0));
     Some(FitResult {
         name: dist.name().to_string(),
         aic,
@@ -255,43 +297,47 @@ fn try_fit_continuous<D: Distribution<X = f64>>(data: &[f64], dist: D) -> Option
 }
 
 /// Per-candidate fit closures. Each fits one distribution end-to-end and
-/// returns a [`FitResult`] (or `None` on failure). Consumed in parallel
-/// by [`fit_all`].
-type ContinuousFitter = fn(&[f64]) -> Option<FitResult>;
+/// returns a [`FitResult`] (or `None` on failure). Receives `(data, sorted)`
+/// where `sorted` is the shared pre-sorted copy. Consumed in parallel by
+/// [`fit_all`].
+type ContinuousFitter = fn(&[f64], &[f64]) -> Option<FitResult>;
 
 const CONTINUOUS_FITTERS: &[ContinuousFitter] = &[
-    |d| Normal::fit(d).ok().and_then(|x| try_fit_continuous(d, x)),
-    |d| {
+    |d, s| Normal::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| {
         crate::distributions::exponential_distribution::Exponential::fit(d)
             .ok()
-            .and_then(|x| try_fit_continuous(d, x))
+            .and_then(|x| try_fit_continuous(s, x))
     },
-    |d| Uniform::fit(d).ok().and_then(|x| try_fit_continuous(d, x)),
-    |d| Gamma::fit(d).ok().and_then(|x| try_fit_continuous(d, x)),
-    |d| {
+    |d, s| Uniform::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| Gamma::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| {
         LogNormal::fit(d)
             .ok()
-            .and_then(|x| try_fit_continuous(d, x))
+            .and_then(|x| try_fit_continuous(s, x))
     },
-    |d| Weibull::fit(d).ok().and_then(|x| try_fit_continuous(d, x)),
-    |d| Beta::fit(d).ok().and_then(|x| try_fit_continuous(d, x)),
-    |d| StudentT::fit(d).ok().and_then(|x| try_fit_continuous(d, x)),
-    |d| {
+    |d, s| Weibull::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| Beta::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| StudentT::fit(d).ok().and_then(|x| try_fit_continuous(s, x)),
+    |d, s| {
         FDistribution::fit(d)
             .ok()
-            .and_then(|x| try_fit_continuous(d, x))
+            .and_then(|x| try_fit_continuous(s, x))
     },
-    |d| {
+    |d, s| {
         ChiSquared::fit(d)
             .ok()
-            .and_then(|x| try_fit_continuous(d, x))
+            .and_then(|x| try_fit_continuous(s, x))
     },
 ];
 
 /// Fit all continuous distributions to `data` and return ranked results (by AIC).
 ///
-/// Each candidate is fit on its own rayon worker (10-way parallelism). The
-/// distribution candidates that fail to fit (e.g. Beta when data are not in
+/// The data is sorted **once** and shared read-only by every candidate's KS
+/// test (the previous implementation re-allocated and re-sorted per
+/// candidate). Candidates run on rayon workers when `data.len() ≥ 1000`;
+/// below that, sequentially — dispatch overhead dominates on small inputs.
+/// Distribution candidates that fail to fit (e.g. Beta when data are not in
 /// (0,1)) are silently skipped.
 pub fn fit_all(data: &[f64]) -> StatsResult<Vec<FitResult>> {
     if data.is_empty() {
@@ -300,10 +346,20 @@ pub fn fit_all(data: &[f64]) -> StatsResult<Vec<FitResult>> {
         });
     }
 
-    let mut results: Vec<FitResult> = CONTINUOUS_FITTERS
-        .par_iter()
-        .filter_map(|fit| fit(data))
-        .collect();
+    let mut sorted = data.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut results: Vec<FitResult> = if data.len() < PAR_THRESHOLD {
+        CONTINUOUS_FITTERS
+            .iter()
+            .filter_map(|fit| fit(data, &sorted))
+            .collect()
+    } else {
+        CONTINUOUS_FITTERS
+            .par_iter()
+            .filter_map(|fit| fit(data, &sorted))
+            .collect()
+    };
 
     if results.is_empty() {
         return Err(StatsError::InvalidInput {
@@ -356,30 +412,18 @@ pub struct SkippedFit {
 /// Err with a SkippedFit (name + reason) on any failure.
 fn try_fit_verbose<D: Distribution<X = f64>>(
     name: &'static str,
-    data: &[f64],
+    sorted: &[f64],
     fit_res: StatsResult<D>,
 ) -> Result<FitResult, SkippedFit> {
     let dist = fit_res.map_err(|e| SkippedFit {
         name,
         reason: format!("fit failed: {e}"),
     })?;
-    let aic = dist
-        .aic(data)
-        .ok()
-        .filter(|x| x.is_finite())
-        .ok_or_else(|| SkippedFit {
-            name,
-            reason: "non-finite AIC (log-likelihood diverged)".to_string(),
-        })?;
-    let bic = dist
-        .bic(data)
-        .ok()
-        .filter(|x| x.is_finite())
-        .ok_or_else(|| SkippedFit {
-            name,
-            reason: "non-finite BIC".to_string(),
-        })?;
-    let ks = ks_test(data, |x| dist.cdf(x).unwrap_or(0.0));
+    let (aic, bic) = ll_diagnostics(&dist, sorted).ok_or_else(|| SkippedFit {
+        name,
+        reason: "non-finite AIC/BIC (log-likelihood diverged)".to_string(),
+    })?;
+    let ks = ks_test_presorted(sorted, |x| dist.cdf(x).unwrap_or(0.0));
     Ok(FitResult {
         name: dist.name().to_string(),
         aic,
@@ -389,25 +433,25 @@ fn try_fit_verbose<D: Distribution<X = f64>>(
     })
 }
 
-type ContinuousVerboseFitter = fn(&[f64]) -> Result<FitResult, SkippedFit>;
+type ContinuousVerboseFitter = fn(&[f64], &[f64]) -> Result<FitResult, SkippedFit>;
 
 const CONTINUOUS_VERBOSE_FITTERS: &[ContinuousVerboseFitter] = &[
-    |d| try_fit_verbose("Normal", d, Normal::fit(d)),
-    |d| {
+    |d, s| try_fit_verbose("Normal", s, Normal::fit(d)),
+    |d, s| {
         try_fit_verbose(
             "Exponential",
-            d,
+            s,
             crate::distributions::exponential_distribution::Exponential::fit(d),
         )
     },
-    |d| try_fit_verbose("Uniform", d, Uniform::fit(d)),
-    |d| try_fit_verbose("Gamma", d, Gamma::fit(d)),
-    |d| try_fit_verbose("LogNormal", d, LogNormal::fit(d)),
-    |d| try_fit_verbose("Weibull", d, Weibull::fit(d)),
-    |d| try_fit_verbose("Beta", d, Beta::fit(d)),
-    |d| try_fit_verbose("StudentT", d, StudentT::fit(d)),
-    |d| try_fit_verbose("FDistribution", d, FDistribution::fit(d)),
-    |d| try_fit_verbose("ChiSquared", d, ChiSquared::fit(d)),
+    |d, s| try_fit_verbose("Uniform", s, Uniform::fit(d)),
+    |d, s| try_fit_verbose("Gamma", s, Gamma::fit(d)),
+    |d, s| try_fit_verbose("LogNormal", s, LogNormal::fit(d)),
+    |d, s| try_fit_verbose("Weibull", s, Weibull::fit(d)),
+    |d, s| try_fit_verbose("Beta", s, Beta::fit(d)),
+    |d, s| try_fit_verbose("StudentT", s, StudentT::fit(d)),
+    |d, s| try_fit_verbose("FDistribution", s, FDistribution::fit(d)),
+    |d, s| try_fit_verbose("ChiSquared", s, ChiSquared::fit(d)),
 ];
 
 pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<SkippedFit>)> {
@@ -417,10 +461,20 @@ pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<Skipped
         });
     }
 
-    let outcomes: Vec<Result<FitResult, SkippedFit>> = CONTINUOUS_VERBOSE_FITTERS
-        .par_iter()
-        .map(|f| f(data))
-        .collect();
+    let mut sorted = data.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let outcomes: Vec<Result<FitResult, SkippedFit>> = if data.len() < PAR_THRESHOLD {
+        CONTINUOUS_VERBOSE_FITTERS
+            .iter()
+            .map(|f| f(data, &sorted))
+            .collect()
+    } else {
+        CONTINUOUS_VERBOSE_FITTERS
+            .par_iter()
+            .map(|f| f(data, &sorted))
+            .collect()
+    };
 
     let (mut results, skipped): (Vec<FitResult>, Vec<SkippedFit>) =
         outcomes
@@ -448,15 +502,14 @@ pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<Skipped
 }
 
 /// Apply [`DiscreteDistribution`]-level diagnostics (AIC / BIC / KS) to one
-/// fitted distribution.
+/// fitted distribution. `sorted` must be the f64 data sorted ascending.
 fn try_fit_discrete<D: DiscreteDistribution>(
-    data: &[f64],
+    sorted: &[f64],
     int_data: &[u64],
     dist: D,
 ) -> Option<FitResult> {
-    let aic = dist.aic(int_data).ok().filter(|x| x.is_finite())?;
-    let bic = dist.bic(int_data).ok().filter(|x| x.is_finite())?;
-    let ks = ks_test_discrete(data, |k| dist.cdf(k).unwrap_or(0.0));
+    let (aic, bic) = ll_diagnostics_discrete(&dist, int_data)?;
+    let ks = ks_test_discrete_presorted(sorted, |k| dist.cdf(k).unwrap_or(0.0));
     Some(FitResult {
         name: dist.name().to_string(),
         aic,
@@ -468,7 +521,7 @@ fn try_fit_discrete<D: DiscreteDistribution>(
 
 fn try_fit_discrete_verbose<D: DiscreteDistribution>(
     name: &'static str,
-    data: &[f64],
+    sorted: &[f64],
     int_data: &[u64],
     fit_res: StatsResult<D>,
 ) -> Result<FitResult, SkippedFit> {
@@ -476,23 +529,11 @@ fn try_fit_discrete_verbose<D: DiscreteDistribution>(
         name,
         reason: format!("fit failed: {e}"),
     })?;
-    let aic = dist
-        .aic(int_data)
-        .ok()
-        .filter(|x| x.is_finite())
-        .ok_or_else(|| SkippedFit {
-            name,
-            reason: "non-finite AIC".to_string(),
-        })?;
-    let bic = dist
-        .bic(int_data)
-        .ok()
-        .filter(|x| x.is_finite())
-        .ok_or_else(|| SkippedFit {
-            name,
-            reason: "non-finite BIC".to_string(),
-        })?;
-    let ks = ks_test_discrete(data, |k| dist.cdf(k).unwrap_or(0.0));
+    let (aic, bic) = ll_diagnostics_discrete(&dist, int_data).ok_or_else(|| SkippedFit {
+        name,
+        reason: "non-finite AIC/BIC (log-likelihood diverged)".to_string(),
+    })?;
+    let ks = ks_test_discrete_presorted(sorted, |k| dist.cdf(k).unwrap_or(0.0));
     Ok(FitResult {
         name: dist.name().to_string(),
         aic,
@@ -502,33 +543,35 @@ fn try_fit_discrete_verbose<D: DiscreteDistribution>(
     })
 }
 
-type DiscreteFitter = fn(&[f64], &[u64]) -> Option<FitResult>;
-type DiscreteVerboseFitter = fn(&[f64], &[u64]) -> Result<FitResult, SkippedFit>;
+/// Receive `(data, sorted, int_data)`: raw data for the fit itself, the
+/// shared pre-sorted copy for KS, and the rounded integers for likelihoods.
+type DiscreteFitter = fn(&[f64], &[f64], &[u64]) -> Option<FitResult>;
+type DiscreteVerboseFitter = fn(&[f64], &[f64], &[u64]) -> Result<FitResult, SkippedFit>;
 
 const DISCRETE_FITTERS: &[DiscreteFitter] = &[
-    |d, i| Poisson::fit(d).ok().and_then(|x| try_fit_discrete(d, i, x)),
-    |d, i| {
+    |d, s, i| Poisson::fit(d).ok().and_then(|x| try_fit_discrete(s, i, x)),
+    |d, s, i| {
         Geometric::fit(d)
             .ok()
-            .and_then(|x| try_fit_discrete(d, i, x))
+            .and_then(|x| try_fit_discrete(s, i, x))
     },
-    |d, i| {
+    |d, s, i| {
         NegativeBinomial::fit(d)
             .ok()
-            .and_then(|x| try_fit_discrete(d, i, x))
+            .and_then(|x| try_fit_discrete(s, i, x))
     },
-    |d, i| {
+    |d, s, i| {
         Binomial::fit(d)
             .ok()
-            .and_then(|x| try_fit_discrete(d, i, x))
+            .and_then(|x| try_fit_discrete(s, i, x))
     },
 ];
 
 const DISCRETE_VERBOSE_FITTERS: &[DiscreteVerboseFitter] = &[
-    |d, i| try_fit_discrete_verbose("Poisson", d, i, Poisson::fit(d)),
-    |d, i| try_fit_discrete_verbose("Geometric", d, i, Geometric::fit(d)),
-    |d, i| try_fit_discrete_verbose("NegativeBinomial", d, i, NegativeBinomial::fit(d)),
-    |d, i| try_fit_discrete_verbose("Binomial", d, i, Binomial::fit(d)),
+    |d, s, i| try_fit_discrete_verbose("Poisson", s, i, Poisson::fit(d)),
+    |d, s, i| try_fit_discrete_verbose("Geometric", s, i, Geometric::fit(d)),
+    |d, s, i| try_fit_discrete_verbose("NegativeBinomial", s, i, NegativeBinomial::fit(d)),
+    |d, s, i| try_fit_discrete_verbose("Binomial", s, i, Binomial::fit(d)),
 ];
 
 /// Like [`fit_all_discrete`] but also reports which distributions were skipped and why.
@@ -540,11 +583,20 @@ pub fn fit_all_discrete_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Ve
     }
 
     let int_data: Vec<u64> = data.iter().map(|&x| x.round() as u64).collect();
+    let mut sorted = data.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let outcomes: Vec<Result<FitResult, SkippedFit>> = DISCRETE_VERBOSE_FITTERS
-        .par_iter()
-        .map(|f| f(data, &int_data))
-        .collect();
+    let outcomes: Vec<Result<FitResult, SkippedFit>> = if data.len() < PAR_THRESHOLD {
+        DISCRETE_VERBOSE_FITTERS
+            .iter()
+            .map(|f| f(data, &sorted, &int_data))
+            .collect()
+    } else {
+        DISCRETE_VERBOSE_FITTERS
+            .par_iter()
+            .map(|f| f(data, &sorted, &int_data))
+            .collect()
+    };
 
     let (mut results, skipped): (Vec<FitResult>, Vec<SkippedFit>) =
         outcomes
@@ -585,11 +637,20 @@ pub fn fit_all_discrete(data: &[f64]) -> StatsResult<Vec<FitResult>> {
     }
 
     let int_data: Vec<u64> = data.iter().map(|&x| x.round() as u64).collect();
+    let mut sorted = data.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let mut results: Vec<FitResult> = DISCRETE_FITTERS
-        .par_iter()
-        .filter_map(|f| f(data, &int_data))
-        .collect();
+    let mut results: Vec<FitResult> = if data.len() < PAR_THRESHOLD {
+        DISCRETE_FITTERS
+            .iter()
+            .filter_map(|f| f(data, &sorted, &int_data))
+            .collect()
+    } else {
+        DISCRETE_FITTERS
+            .par_iter()
+            .filter_map(|f| f(data, &sorted, &int_data))
+            .collect()
+    };
 
     if results.is_empty() {
         return Err(StatsError::InvalidInput {

--- a/src/distributions/fitting.rs
+++ b/src/distributions/fitting.rs
@@ -75,6 +75,7 @@ use crate::distributions::{
     weibull::Weibull,
 };
 use crate::error::{StatsError, StatsResult};
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 // ── Data kind detection ────────────────────────────────────────────────────────
@@ -250,6 +251,7 @@ pub struct FitResult {
 
 /// Below this many data points the rayon dispatch overhead (task setup +
 /// pool wake-up) exceeds the cost of fitting all candidates sequentially.
+#[cfg(feature = "parallel")]
 const PAR_THRESHOLD: usize = 1000;
 
 /// Compute AIC and BIC from a **single** log-likelihood pass.
@@ -349,17 +351,23 @@ pub fn fit_all(data: &[f64]) -> StatsResult<Vec<FitResult>> {
     let mut sorted = data.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let mut results: Vec<FitResult> = if data.len() < PAR_THRESHOLD {
-        CONTINUOUS_FITTERS
-            .iter()
-            .filter_map(|fit| fit(data, &sorted))
-            .collect()
-    } else {
+    #[cfg(feature = "parallel")]
+    let mut results: Vec<FitResult> = if data.len() >= PAR_THRESHOLD {
         CONTINUOUS_FITTERS
             .par_iter()
             .filter_map(|fit| fit(data, &sorted))
             .collect()
+    } else {
+        CONTINUOUS_FITTERS
+            .iter()
+            .filter_map(|fit| fit(data, &sorted))
+            .collect()
     };
+    #[cfg(not(feature = "parallel"))]
+    let mut results: Vec<FitResult> = CONTINUOUS_FITTERS
+        .iter()
+        .filter_map(|fit| fit(data, &sorted))
+        .collect();
 
     if results.is_empty() {
         return Err(StatsError::InvalidInput {
@@ -464,17 +472,23 @@ pub fn fit_all_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Vec<Skipped
     let mut sorted = data.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let outcomes: Vec<Result<FitResult, SkippedFit>> = if data.len() < PAR_THRESHOLD {
-        CONTINUOUS_VERBOSE_FITTERS
-            .iter()
-            .map(|f| f(data, &sorted))
-            .collect()
-    } else {
+    #[cfg(feature = "parallel")]
+    let outcomes: Vec<Result<FitResult, SkippedFit>> = if data.len() >= PAR_THRESHOLD {
         CONTINUOUS_VERBOSE_FITTERS
             .par_iter()
             .map(|f| f(data, &sorted))
             .collect()
+    } else {
+        CONTINUOUS_VERBOSE_FITTERS
+            .iter()
+            .map(|f| f(data, &sorted))
+            .collect()
     };
+    #[cfg(not(feature = "parallel"))]
+    let outcomes: Vec<Result<FitResult, SkippedFit>> = CONTINUOUS_VERBOSE_FITTERS
+        .iter()
+        .map(|f| f(data, &sorted))
+        .collect();
 
     let (mut results, skipped): (Vec<FitResult>, Vec<SkippedFit>) =
         outcomes
@@ -586,17 +600,23 @@ pub fn fit_all_discrete_verbose(data: &[f64]) -> StatsResult<(Vec<FitResult>, Ve
     let mut sorted = data.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let outcomes: Vec<Result<FitResult, SkippedFit>> = if data.len() < PAR_THRESHOLD {
-        DISCRETE_VERBOSE_FITTERS
-            .iter()
-            .map(|f| f(data, &sorted, &int_data))
-            .collect()
-    } else {
+    #[cfg(feature = "parallel")]
+    let outcomes: Vec<Result<FitResult, SkippedFit>> = if data.len() >= PAR_THRESHOLD {
         DISCRETE_VERBOSE_FITTERS
             .par_iter()
             .map(|f| f(data, &sorted, &int_data))
             .collect()
+    } else {
+        DISCRETE_VERBOSE_FITTERS
+            .iter()
+            .map(|f| f(data, &sorted, &int_data))
+            .collect()
     };
+    #[cfg(not(feature = "parallel"))]
+    let outcomes: Vec<Result<FitResult, SkippedFit>> = DISCRETE_VERBOSE_FITTERS
+        .iter()
+        .map(|f| f(data, &sorted, &int_data))
+        .collect();
 
     let (mut results, skipped): (Vec<FitResult>, Vec<SkippedFit>) =
         outcomes
@@ -640,17 +660,23 @@ pub fn fit_all_discrete(data: &[f64]) -> StatsResult<Vec<FitResult>> {
     let mut sorted = data.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let mut results: Vec<FitResult> = if data.len() < PAR_THRESHOLD {
-        DISCRETE_FITTERS
-            .iter()
-            .filter_map(|f| f(data, &sorted, &int_data))
-            .collect()
-    } else {
+    #[cfg(feature = "parallel")]
+    let mut results: Vec<FitResult> = if data.len() >= PAR_THRESHOLD {
         DISCRETE_FITTERS
             .par_iter()
             .filter_map(|f| f(data, &sorted, &int_data))
             .collect()
+    } else {
+        DISCRETE_FITTERS
+            .iter()
+            .filter_map(|f| f(data, &sorted, &int_data))
+            .collect()
     };
+    #[cfg(not(feature = "parallel"))]
+    let mut results: Vec<FitResult> = DISCRETE_FITTERS
+        .iter()
+        .filter_map(|f| f(data, &sorted, &int_data))
+        .collect();
 
     if results.is_empty() {
         return Err(StatsError::InvalidInput {

--- a/src/distributions/fitting.rs
+++ b/src/distributions/fitting.rs
@@ -210,7 +210,7 @@ pub fn ks_test_discrete_presorted(sorted: &[f64], cdf: impl Fn(u64) -> f64) -> K
 }
 
 /// Approximate p-value of the Kolmogorov distribution at `x`.
-fn kolmogorov_p(x: f64) -> f64 {
+pub(crate) fn kolmogorov_p(x: f64) -> f64 {
     if x <= 0.0 {
         return 1.0;
     }
@@ -283,10 +283,7 @@ fn ll_diagnostics_discrete<D: Distribution<X = u64>>(dist: &D, data: &[u64]) -> 
 /// distribution, producing a [`FitResult`]. Returns `None` if any of the
 /// diagnostics fails (non-finite log-likelihood or fit error).
 /// `sorted` must be `data` sorted ascending (shared across candidates).
-fn try_fit_continuous<D: Distribution<X = f64>>(
-    sorted: &[f64],
-    dist: D,
-) -> Option<FitResult> {
+fn try_fit_continuous<D: Distribution<X = f64>>(sorted: &[f64], dist: D) -> Option<FitResult> {
     let (aic, bic) = ll_diagnostics(&dist, sorted)?;
     let ks = ks_test_presorted(sorted, |x| dist.cdf(x).unwrap_or(0.0));
     Some(FitResult {

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -151,6 +151,16 @@ impl Distribution for Gamma {
         }
         Ok(regularized_incomplete_gamma(self.alpha, self.beta * x))
     }
+    /// Exact tail: `S(x) = Q(α, βx)` (upper regularized incomplete gamma).
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= 0.0 {
+            return Ok(1.0);
+        }
+        Ok(crate::utils::special_functions::regularized_incomplete_gamma_upper(
+            self.alpha,
+            self.beta * x,
+        ))
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -127,6 +127,24 @@ impl Distribution for Gamma {
             - ln_gamma(self.alpha))
     }
 
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // α·ln β − ln Γ(α) hoisted out of the per-point loop.
+        let log_norm = self.alpha * self.beta.ln() - ln_gamma(self.alpha);
+        let a1 = self.alpha - 1.0;
+        let mut acc = 0.0_f64;
+        for &x in data {
+            if x <= 0.0 {
+                return f64::NEG_INFINITY;
+            }
+            acc += a1 * x.ln() - self.beta * x;
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
     fn cdf(&self, x: f64) -> StatsResult<f64> {
         if x <= 0.0 {
             return Ok(0.0);

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -164,10 +164,12 @@ impl Distribution for Gamma {
         if x <= 0.0 {
             return Ok(1.0);
         }
-        Ok(crate::utils::special_functions::regularized_incomplete_gamma_upper(
-            self.alpha,
-            self.beta * x,
-        ))
+        Ok(
+            crate::utils::special_functions::regularized_incomplete_gamma_upper(
+                self.alpha,
+                self.beta * x,
+            ),
+        )
     }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -46,6 +46,7 @@ use crate::utils::special_functions::{bisect_inverse_cdf, ln_gamma, regularized_
 /// assert!((g.mean() - 2.0).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gamma {
     /// Shape parameter α > 0
     pub alpha: f64,
@@ -56,6 +57,13 @@ pub struct Gamma {
 impl Gamma {
     /// Creates a `Gamma(α, β)` distribution.
     pub fn new(alpha: f64, beta: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !alpha.is_finite() || !beta.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Gamma::new: parameters must be finite".to_string(),
+            });
+        }
         if alpha <= 0.0 || beta <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "Gamma::new: alpha and beta must be positive".to_string(),

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -33,7 +33,7 @@
 
 use crate::distributions::traits::Distribution;
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::{bisect_inverse_cdf, ln_gamma, regularized_incomplete_gamma};
+use crate::utils::special_functions::{ln_gamma, regularized_incomplete_gamma};
 
 /// Gamma distribution Gamma(α, β) with shape α and rate β.
 ///
@@ -194,8 +194,9 @@ impl Distribution for Gamma {
         let beta = self.beta;
         // Upper bound: mean + 10*std_dev should cover virtually all mass
         let hi = (alpha / beta) + 10.0 * (alpha / beta / beta).sqrt();
-        Ok(bisect_inverse_cdf(
+        Ok(crate::utils::special_functions::newton_inverse_cdf(
             |x| regularized_incomplete_gamma(alpha, beta * x),
+            |x| self.pdf(x).unwrap_or(0.0),
             p,
             0.0,
             hi.max(1.0),

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -58,7 +58,7 @@ impl Gamma {
     /// Creates a `Gamma(α, β)` distribution.
     pub fn new(alpha: f64, beta: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !alpha.is_finite() || !beta.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Gamma::new: parameters must be finite".to_string(),

--- a/src/distributions/gamma_distribution.rs
+++ b/src/distributions/gamma_distribution.rs
@@ -135,6 +135,12 @@ impl Distribution for Gamma {
             - ln_gamma(self.alpha))
     }
 
+    /// Marsaglia-Tsang squeeze sampling: ~1.05 ziggurat normals + one
+    /// uniform per draw — no per-sample quantile bisection.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        Ok(gamma_sample_unit_rate(rng, self.alpha) / self.beta)
+    }
+
     fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
         Ok(self.log_likelihood_fast(data))
     }
@@ -202,6 +208,40 @@ impl Distribution for Gamma {
 
     fn variance(&self) -> f64 {
         self.alpha / (self.beta * self.beta)
+    }
+}
+
+/// One `Gamma(α, rate = 1)` draw via Marsaglia & Tsang's squeeze method
+/// (2000): for α ≥ 1, `d·(1+c·Z)³` with a fast squeeze acceptance
+/// (~96% of draws need one normal + one uniform). For α < 1, boost from
+/// `Gamma(α+1)` by a `U^{1/α}` factor.
+///
+/// Shared by the Beta, ChiSquared, StudentT and F samplers.
+pub(crate) fn gamma_sample_unit_rate(rng: &mut dyn rand::RngCore, alpha: f64) -> f64 {
+    use crate::distributions::normal_distribution::{uniform01, ziggurat_standard_normal};
+
+    if alpha < 1.0 {
+        let u = uniform01(rng);
+        return gamma_sample_unit_rate(rng, alpha + 1.0) * u.powf(1.0 / alpha);
+    }
+    let d = alpha - 1.0 / 3.0;
+    let c = 1.0 / (9.0 * d).sqrt();
+    loop {
+        let x = ziggurat_standard_normal(rng);
+        let v = 1.0 + c * x;
+        if v <= 0.0 {
+            continue;
+        }
+        let v = v * v * v;
+        let u = uniform01(rng);
+        let x2 = x * x;
+        // Cheap squeeze first; the exact log test only on the rare misses.
+        if u < 1.0 - 0.0331 * x2 * x2 {
+            return d * v;
+        }
+        if u.ln() < 0.5 * x2 + d * (1.0 - v + v.ln()) {
+            return d * v;
+        }
     }
 }
 

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -110,8 +110,10 @@ impl crate::distributions::traits::Distribution for Geometric {
         if k == 0 {
             return Ok(0.0);
         }
-        // CDF(k) = 1 - (1-p)^k  — use powf(f64) to handle k > i32::MAX correctly.
-        Ok(1.0 - (1.0 - self.p).powf(k as f64))
+        // CDF(k) = 1 - (1-p)^k, computed as −expm1(k·ln_1p(−p)) so both the
+        // small-p and the far-tail regimes keep relative precision.
+        // (k as f64 handles k > i32::MAX correctly.)
+        Ok(-((k as f64) * (-self.p).ln_1p()).exp_m1())
     }
 
     /// Closed-form quantile: k = ⌈ln(1−p) / ln(1−self.p)⌉.
@@ -139,7 +141,7 @@ impl crate::distributions::traits::Distribution for Geometric {
         // CDF(k) = 1 - (1-p_param)^k ≥ p_target
         // → (1-p_param)^k ≤ 1 - p_target
         // → k ≥ ln(1 - p_target) / ln(1 - p_param)   [denominator < 0, inequality flips]
-        let k = (1.0 - p).ln() / (1.0 - self.p).ln();
+        let k = (-p).ln_1p() / (-self.p).ln_1p();
         Ok(k.ceil().max(1.0) as u64)
     }
 

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -29,6 +29,7 @@
 //! ```
 
 use crate::error::{StatsError, StatsResult};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Geometric distribution Geometric(p).
@@ -41,7 +42,8 @@ use serde::{Deserialize, Serialize};
 /// let g = Geometric::new(0.25).unwrap();
 /// assert!((g.mean() - 4.0).abs() < 1e-10);
 /// ```
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Geometric {
     /// Success probability p ∈ (0, 1]
     pub p: f64,

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -125,8 +125,16 @@ impl crate::distributions::traits::Distribution for Geometric {
         if p == 0.0 {
             return Ok(0);
         }
-        if p == 1.0 || self.p == 1.0 {
-            return Ok(1);
+        if self.p == 1.0 {
+            return Ok(1); // all mass at k = 1
+        }
+        if p == 1.0 {
+            // Unbounded support: the p = 1 quantile is +∞, not 1 (CDF(1) =
+            // p_param < 1 here — the old code conflated the two conditions).
+            return Err(StatsError::InvalidInput {
+                message: "Geometric::inverse_cdf: p = 1.0 has no finite quantile; use p < 1"
+                    .to_string(),
+            });
         }
         // CDF(k) = 1 - (1-p_param)^k ≥ p_target
         // → (1-p_param)^k ≤ 1 - p_target

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -115,6 +115,14 @@ impl crate::distributions::traits::Distribution for Geometric {
         // (k as f64 handles k > i32::MAX correctly.)
         Ok(-((k as f64) * (-self.p).ln_1p()).exp_m1())
     }
+    /// Exact tail: `S(k) = (1−p)^k`, computed as `exp(k·ln_1p(−p))`.
+    fn sf(&self, k: u64) -> StatsResult<f64> {
+        if k == 0 {
+            // Avoids 0 · (−∞) = NaN when p = 1.
+            return Ok(1.0);
+        }
+        Ok(((k as f64) * (-self.p).ln_1p()).exp())
+    }
 
     /// Closed-form quantile: k = ⌈ln(1−p) / ln(1−self.p)⌉.
     fn inverse_cdf(&self, p: f64) -> crate::error::StatsResult<u64> {

--- a/src/distributions/laplace.rs
+++ b/src/distributions/laplace.rs
@@ -1,0 +1,285 @@
+//! # Laplace Distribution
+//!
+//! The Laplace(μ, b) distribution (double exponential) is a symmetric,
+//! sharply-peaked distribution with exponential tails — heavier than the
+//! Normal but with all moments finite.
+//!
+//! **PDF**: f(x; μ, b) = exp(−|x − μ|/b) / (2b)
+//!
+//! **CDF**: F(x) = ½·exp((x − μ)/b) for x < μ, 1 − ½·exp(−(x − μ)/b) for x ≥ μ
+//!
+//! **Mean**: μ   **Variance**: 2b²
+//!
+//! ## Applications
+//!
+//! - Differential privacy (the Laplace mechanism)
+//! - Robust regression (L1 loss ⇔ Laplace likelihood)
+//! - Modeling errors with occasional large deviations
+//!
+//! ## Example
+//!
+//! ```rust
+//! use rs_stats::distributions::laplace::Laplace;
+//! use rs_stats::distributions::traits::Distribution;
+//!
+//! let l = Laplace::new(0.0, 1.0).unwrap();
+//! assert!((l.cdf(0.0).unwrap() - 0.5).abs() < 1e-15);
+//! assert!((l.variance() - 2.0).abs() < 1e-15);
+//! ```
+
+use crate::distributions::traits::Distribution;
+use crate::error::{StatsError, StatsResult};
+use std::f64::consts::LN_2;
+
+/// Laplace distribution Laplace(μ, b).
+///
+/// # Examples
+/// ```
+/// use rs_stats::distributions::laplace::Laplace;
+/// use rs_stats::distributions::traits::Distribution;
+///
+/// let l = Laplace::new(1.0, 2.0).unwrap();
+/// assert!((l.mean() - 1.0).abs() < 1e-15);
+/// assert!((l.variance() - 8.0).abs() < 1e-15);
+/// ```
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Laplace {
+    /// Location parameter μ (mean, median and mode)
+    pub mu: f64,
+    /// Scale parameter b > 0 (diversity)
+    pub b: f64,
+}
+
+impl Laplace {
+    /// Creates a `Laplace(μ, b)` distribution.
+    pub fn new(mu: f64, b: f64) -> StatsResult<Self> {
+        if !mu.is_finite() || !b.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Laplace::new: parameters must be finite".to_string(),
+            });
+        }
+        if b <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Laplace::new: b must be positive".to_string(),
+            });
+        }
+        Ok(Self { mu, b })
+    }
+
+    /// Exact MLE: μ̂ = median(data), b̂ = mean(|xᵢ − μ̂|).
+    ///
+    /// The sample median maximises the likelihood in μ (L1 loss), and the
+    /// mean absolute deviation from the median is the closed-form MLE of b.
+    pub fn fit(data: &[f64]) -> StatsResult<Self> {
+        if data.is_empty() {
+            return Err(StatsError::InvalidInput {
+                message: "Laplace::fit: data must not be empty".to_string(),
+            });
+        }
+        let mut sorted = data.to_vec();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = sorted.len();
+        let mu = if n % 2 == 1 {
+            sorted[n / 2]
+        } else {
+            (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+        };
+        let b = data.iter().map(|&x| (x - mu).abs()).sum::<f64>() / n as f64;
+        if b <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Laplace::fit: data has zero mean absolute deviation".to_string(),
+            });
+        }
+        Self::new(mu, b)
+    }
+}
+
+impl Distribution for Laplace {
+    type X = f64;
+    fn name(&self) -> &str {
+        "Laplace"
+    }
+    fn num_params(&self) -> usize {
+        2
+    }
+
+    fn pdf(&self, x: f64) -> StatsResult<f64> {
+        Ok(self.logpdf(x)?.exp())
+    }
+
+    fn logpdf(&self, x: f64) -> StatsResult<f64> {
+        Ok(-LN_2 - self.b.ln() - (x - self.mu).abs() / self.b)
+    }
+
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // ln(2b) hoisted out of the loop — the per-point work is branch-free
+        // (abs + multiply-add), so LLVM can autovectorise it.
+        let log_norm = -LN_2 - self.b.ln();
+        let inv_b = 1.0 / self.b;
+        let mut acc = 0.0_f64;
+        for &x in data {
+            acc -= (x - self.mu).abs() * inv_b;
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
+    fn cdf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.mu) / self.b;
+        // Exact exponential branches: the left tail ½·e^z never suffers the
+        // 1 − (≈1) cancellation a single-formula CDF would.
+        Ok(if z < 0.0 {
+            0.5 * z.exp()
+        } else {
+            1.0 - 0.5 * (-z).exp()
+        })
+    }
+
+    /// Exact tail: `S(x) = ½·exp(−(x − μ)/b)` for `x ≥ μ` — full relative
+    /// precision arbitrarily deep in the right tail.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.mu) / self.b;
+        Ok(if z > 0.0 {
+            0.5 * (-z).exp()
+        } else {
+            1.0 - 0.5 * z.exp()
+        })
+    }
+
+    fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
+        if !(0.0..=1.0).contains(&p) {
+            return Err(StatsError::InvalidInput {
+                message: "Laplace::inverse_cdf: p must be in [0, 1]".to_string(),
+            });
+        }
+        if p == 0.0 {
+            return Ok(f64::NEG_INFINITY);
+        }
+        if p == 1.0 {
+            return Ok(f64::INFINITY);
+        }
+        // Closed-form branches:
+        //   p < ½ : x = μ + b·ln(2p)
+        //   p ≥ ½ : x = μ − b·ln(2(1 − p)),  with ln(1 − p) via ln_1p(−p)
+        //           so p's low bits survive for p → 1.
+        Ok(if p < 0.5 {
+            self.mu + self.b * (2.0 * p).ln()
+        } else {
+            self.mu - self.b * (LN_2 + (-p).ln_1p())
+        })
+    }
+
+    fn mean(&self) -> f64 {
+        self.mu
+    }
+
+    fn variance(&self) -> f64 {
+        2.0 * self.b * self.b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.laplace(loc=1, scale=2).
+    const TOL: f64 = 1e-12;
+
+    #[test]
+    fn test_laplace_pdf_vs_scipy() {
+        let l = Laplace::new(1.0, 2.0).unwrap();
+        assert!((l.pdf(3.0).unwrap() - 0.09196986029286058).abs() < TOL);
+        assert!((l.logpdf(-0.5).unwrap() - (-2.136294361119891)).abs() < TOL);
+        // Peak: pdf(μ) = 1/(2b)
+        assert!((l.pdf(1.0).unwrap() - 0.25).abs() < TOL);
+    }
+
+    #[test]
+    fn test_laplace_cdf_sf_vs_scipy() {
+        let l = Laplace::new(1.0, 2.0).unwrap();
+        assert!((l.cdf(3.0).unwrap() - 0.8160602794142788).abs() < TOL);
+        assert!((l.cdf(-0.5).unwrap() - 0.23618327637050734).abs() < TOL);
+        assert!((l.sf(3.0).unwrap() - 0.18393972058572117).abs() < TOL);
+        assert!((l.cdf(1.0).unwrap() - 0.5).abs() < TOL);
+        assert!((l.sf(1.0).unwrap() - 0.5).abs() < TOL);
+    }
+
+    #[test]
+    fn test_laplace_deep_tail_sf() {
+        let l = Laplace::new(1.0, 2.0).unwrap();
+        // scipy: laplace(1, 2).sf(100) = 1.5899854500988748e-22
+        let s = l.sf(100.0).unwrap();
+        assert!(s > 0.0, "sf(100) underflowed");
+        assert!((s / 1.5899854500988748e-22 - 1.0).abs() < 1e-12);
+        // 1 − cdf would return exactly 0 here
+        assert_eq!(1.0 - l.cdf(100.0).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_laplace_inverse_cdf_vs_scipy() {
+        let l = Laplace::new(1.0, 2.0).unwrap();
+        assert!((l.inverse_cdf(0.2).unwrap() - (-0.83258146374831)).abs() < TOL);
+        assert!((l.inverse_cdf(0.8).unwrap() - 2.8325814637483107).abs() < TOL);
+        assert!((l.inverse_cdf(0.5).unwrap() - 1.0).abs() < TOL);
+        assert_eq!(l.inverse_cdf(0.0).unwrap(), f64::NEG_INFINITY);
+        assert_eq!(l.inverse_cdf(1.0).unwrap(), f64::INFINITY);
+        assert!(l.inverse_cdf(-0.1).is_err());
+        assert!(l.inverse_cdf(1.5).is_err());
+    }
+
+    #[test]
+    fn test_laplace_roundtrip() {
+        let l = Laplace::new(-2.0, 0.5).unwrap();
+        for &x in &[-10.0, -2.5, -2.0, -1.9, 0.0, 3.0] {
+            let p = l.cdf(x).unwrap();
+            let x_back = l.inverse_cdf(p).unwrap();
+            assert!((x - x_back).abs() < 1e-10 * x.abs().max(1.0), "x={x}");
+        }
+        for &p in &[1e-12, 0.1, 0.5, 0.9, 1.0 - 1e-12] {
+            let x = l.inverse_cdf(p).unwrap();
+            let p_back = l.cdf(x).unwrap();
+            assert!((p - p_back).abs() < 1e-13 * p.max(1e-3), "p={p}");
+        }
+    }
+
+    #[test]
+    fn test_laplace_fit_mle() {
+        // Odd length: median = 2, MAD from median = (2+1+0+1+3)/5 = 1.4
+        let data = vec![0.0, 1.0, 2.0, 3.0, 5.0];
+        let l = Laplace::fit(&data).unwrap();
+        assert!((l.mu - 2.0).abs() < 1e-12);
+        assert!((l.b - 1.4).abs() < 1e-12);
+        // Constant data: b = 0 → error
+        assert!(Laplace::fit(&[7.0; 5]).is_err());
+        assert!(Laplace::fit(&[]).is_err());
+    }
+
+    #[test]
+    fn test_laplace_moments() {
+        let l = Laplace::new(1.0, 2.0).unwrap();
+        assert!((l.mean() - 1.0).abs() < TOL);
+        assert!((l.variance() - 8.0).abs() < TOL);
+    }
+
+    #[test]
+    fn test_laplace_log_likelihood_fast_matches_logpdf_sum() {
+        let l = Laplace::new(0.5, 1.5).unwrap();
+        let data = vec![-3.0, 0.0, 0.5, 2.0, 10.0];
+        let expected: f64 = data.iter().map(|&x| l.logpdf(x).unwrap()).sum();
+        assert!((l.log_likelihood_fast(&data) - expected).abs() < 1e-10);
+        assert!((l.log_likelihood(&data).unwrap() - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_laplace_invalid_params() {
+        assert!(Laplace::new(f64::NAN, 1.0).is_err());
+        assert!(Laplace::new(0.0, f64::NAN).is_err());
+        assert!(Laplace::new(f64::NEG_INFINITY, 1.0).is_err());
+        assert!(Laplace::new(0.0, 0.0).is_err());
+        assert!(Laplace::new(0.0, -2.0).is_err());
+    }
+}

--- a/src/distributions/logistic.rs
+++ b/src/distributions/logistic.rs
@@ -1,0 +1,282 @@
+//! # Logistic Distribution
+//!
+//! The Logistic(μ, s) distribution looks like a Normal with slightly heavier
+//! tails; its CDF is the logistic (sigmoid) function, which makes it the
+//! natural noise model behind logistic regression.
+//!
+//! **PDF**: f(x; μ, s) = e^(−z) / (s·(1 + e^(−z))²),  z = (x − μ)/s
+//!
+//! **CDF**: F(x) = 1 / (1 + e^(−z))   **SF**: S(x) = 1 / (1 + e^(z)) (exact tail)
+//!
+//! **Mean**: μ   **Variance**: s²π²/3
+//!
+//! ## Applications
+//!
+//! - Logistic regression / discrete choice models (latent-utility noise)
+//! - Growth curves (population, adoption)
+//! - Item response theory (Rasch models)
+//!
+//! ## Example
+//!
+//! ```rust
+//! use rs_stats::distributions::logistic::Logistic;
+//! use rs_stats::distributions::traits::Distribution;
+//!
+//! let l = Logistic::new(0.0, 1.0).unwrap();
+//! assert!((l.cdf(0.0).unwrap() - 0.5).abs() < 1e-15);
+//! assert!((l.variance() - std::f64::consts::PI.powi(2) / 3.0).abs() < 1e-12);
+//! ```
+
+use crate::distributions::traits::Distribution;
+use crate::error::{StatsError, StatsResult};
+use std::f64::consts::PI;
+
+/// Logistic distribution Logistic(μ, s).
+///
+/// # Examples
+/// ```
+/// use rs_stats::distributions::logistic::Logistic;
+/// use rs_stats::distributions::traits::Distribution;
+///
+/// let l = Logistic::new(2.0, 1.5).unwrap();
+/// assert!((l.mean() - 2.0).abs() < 1e-15);
+/// ```
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Logistic {
+    /// Location parameter μ (mean, median and mode)
+    pub mu: f64,
+    /// Scale parameter s > 0
+    pub s: f64,
+}
+
+impl Logistic {
+    /// Creates a `Logistic(μ, s)` distribution.
+    pub fn new(mu: f64, s: f64) -> StatsResult<Self> {
+        if !mu.is_finite() || !s.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Logistic::new: parameters must be finite".to_string(),
+            });
+        }
+        if s <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Logistic::new: s must be positive".to_string(),
+            });
+        }
+        Ok(Self { mu, s })
+    }
+
+    /// Method-of-moments fitting: μ̂ = mean(data), ŝ = √3·σ̂/π where σ̂ is
+    /// the population standard deviation (Var = s²π²/3 ⇒ s = σ√3/π).
+    pub fn fit(data: &[f64]) -> StatsResult<Self> {
+        if data.is_empty() {
+            return Err(StatsError::InvalidInput {
+                message: "Logistic::fit: data must not be empty".to_string(),
+            });
+        }
+        // Single-pass online mean+variance (Welford).
+        let mut count = 0.0_f64;
+        let mut mean = 0.0_f64;
+        let mut m2 = 0.0_f64;
+        for &x in data {
+            count += 1.0;
+            let delta = x - mean;
+            mean += delta / count;
+            m2 += delta * (x - mean);
+        }
+        let std_pop = (m2 / count).sqrt();
+        if std_pop <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Logistic::fit: data has zero variance".to_string(),
+            });
+        }
+        Self::new(mean, 3.0_f64.sqrt() * std_pop / PI)
+    }
+}
+
+impl Distribution for Logistic {
+    type X = f64;
+    fn name(&self) -> &str {
+        "Logistic"
+    }
+    fn num_params(&self) -> usize {
+        2
+    }
+
+    fn pdf(&self, x: f64) -> StatsResult<f64> {
+        Ok(self.logpdf(x)?.exp())
+    }
+
+    fn logpdf(&self, x: f64) -> StatsResult<f64> {
+        // Symmetric stable form: ln f = −|z| − 2·ln(1 + e^(−|z|)) − ln s.
+        // e^(−|z|) never overflows and ln_1p keeps precision in both tails.
+        let az = ((x - self.mu) / self.s).abs();
+        Ok(-az - 2.0 * (-az).exp().ln_1p() - self.s.ln())
+    }
+
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // ln s hoisted out of the per-point loop.
+        let log_norm = -self.s.ln();
+        let inv_s = 1.0 / self.s;
+        let mut acc = 0.0_f64;
+        for &x in data {
+            let az = ((x - self.mu) * inv_s).abs();
+            acc -= az + 2.0 * (-az).exp().ln_1p();
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
+    fn cdf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.mu) / self.s;
+        // 1/(1 + e^(−z)): exact in the left tail (→ e^z), saturates
+        // harmlessly to 1 in the right tail (use `sf` there).
+        Ok(1.0 / (1.0 + (-z).exp()))
+    }
+
+    /// Exact tail: `S(x) = 1/(1 + exp(z))` — for large `z` this evaluates to
+    /// `≈ e^(−z)` with full relative precision (never computed as 1 − cdf).
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.mu) / self.s;
+        Ok(1.0 / (1.0 + z.exp()))
+    }
+
+    fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
+        if !(0.0..=1.0).contains(&p) {
+            return Err(StatsError::InvalidInput {
+                message: "Logistic::inverse_cdf: p must be in [0, 1]".to_string(),
+            });
+        }
+        if p == 0.0 {
+            return Ok(f64::NEG_INFINITY);
+        }
+        if p == 1.0 {
+            return Ok(f64::INFINITY);
+        }
+        // Closed-form logit: x = μ + s·ln(p/(1 − p)) = μ + s·(ln p − ln(1 − p)),
+        // with ln(1 − p) via ln_1p(−p) so p's low bits survive for p → 1.
+        Ok(self.mu + self.s * (p.ln() - (-p).ln_1p()))
+    }
+
+    fn mean(&self) -> f64 {
+        self.mu
+    }
+
+    fn variance(&self) -> f64 {
+        self.s * self.s * PI * PI / 3.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.logistic(loc=2, scale=1.5).
+    const TOL: f64 = 1e-12;
+
+    #[test]
+    fn test_logistic_pdf_vs_scipy() {
+        let l = Logistic::new(2.0, 1.5).unwrap();
+        assert!((l.pdf(4.0).unwrap() - 0.11006067310193583).abs() < TOL);
+        assert!((l.logpdf(4.0).unwrap() - (-2.206723491596594)).abs() < TOL);
+        // Peak: pdf(μ) = 1/(4s)
+        assert!((l.pdf(2.0).unwrap() - 1.0 / 6.0).abs() < TOL);
+    }
+
+    #[test]
+    fn test_logistic_cdf_sf_vs_scipy() {
+        let l = Logistic::new(2.0, 1.5).unwrap();
+        assert!((l.cdf(4.0).unwrap() - 0.791391472673955).abs() < TOL);
+        assert!((l.sf(4.0).unwrap() - 0.20860852732604496).abs() < TOL);
+        assert!((l.cdf(2.0).unwrap() - 0.5).abs() < TOL);
+        assert!((l.sf(2.0).unwrap() - 0.5).abs() < TOL);
+    }
+
+    #[test]
+    fn test_logistic_deep_tail_sf() {
+        let l = Logistic::new(2.0, 1.5).unwrap();
+        // scipy: logistic(2, 1.5).sf(50) = 1.2664165549094016e-14 ≈ e^(−48/1.5)
+        let s = l.sf(50.0).unwrap();
+        assert!(s > 0.0, "sf(50) underflowed");
+        assert!((s / 1.2664165549094016e-14 - 1.0).abs() < 1e-12);
+        // 1 − cdf loses most significant digits here (sf keeps them all)
+        let naive = 1.0 - l.cdf(50.0).unwrap();
+        assert!((naive / 1.2664165549094016e-14 - 1.0).abs() > 1e-8);
+        // Deep left tail via cdf ≈ e^z stays exact too
+        let left = l.cdf(-50.0).unwrap();
+        assert!(left > 0.0 && left < 1e-14);
+    }
+
+    #[test]
+    fn test_logistic_inverse_cdf_vs_scipy() {
+        let l = Logistic::new(2.0, 1.5).unwrap();
+        assert!((l.inverse_cdf(0.3).unwrap() - 0.7290532094191944).abs() < TOL);
+        assert!((l.inverse_cdf(0.999).unwrap() - 12.360132167972829).abs() < TOL);
+        assert!((l.inverse_cdf(0.5).unwrap() - 2.0).abs() < TOL);
+        assert_eq!(l.inverse_cdf(0.0).unwrap(), f64::NEG_INFINITY);
+        assert_eq!(l.inverse_cdf(1.0).unwrap(), f64::INFINITY);
+        assert!(l.inverse_cdf(-0.2).is_err());
+        assert!(l.inverse_cdf(1.2).is_err());
+    }
+
+    #[test]
+    fn test_logistic_roundtrip() {
+        let l = Logistic::new(-1.0, 0.4).unwrap();
+        for &x in &[-8.0, -1.5, -1.0, -0.9, 0.0, 6.0] {
+            let p = l.cdf(x).unwrap();
+            let x_back = l.inverse_cdf(p).unwrap();
+            // x → p → x through the saturating region of the CDF (p → 1) is
+            // inherently ill-conditioned; 1e-7 absolute is the honest bound.
+            assert!((x - x_back).abs() < 1e-7 * x.abs().max(1.0), "x={x}");
+        }
+        for &p in &[1e-12, 0.1, 0.5, 0.9, 1.0 - 1e-12] {
+            let x = l.inverse_cdf(p).unwrap();
+            let p_back = l.cdf(x).unwrap();
+            assert!((p - p_back).abs() < 1e-12 * p.max(1e-3), "p={p}");
+        }
+    }
+
+    #[test]
+    fn test_logistic_moments_vs_scipy() {
+        let l = Logistic::new(2.0, 1.5).unwrap();
+        assert!((l.mean() - 2.0).abs() < TOL);
+        // scipy: logistic(2, 1.5).var() = 7.4022033008170185
+        assert!((l.variance() - 7.4022033008170185).abs() < TOL);
+    }
+
+    #[test]
+    fn test_logistic_fit_mom() {
+        // mean = 3, population variance = 2 → s = √3·√2/π
+        let data = vec![1.0, 3.0, 5.0, 3.0, 2.0, 4.0];
+        let l = Logistic::fit(&data).unwrap();
+        let n = data.len() as f64;
+        let mean = data.iter().sum::<f64>() / n;
+        let var = data.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / n;
+        assert!((l.mu - mean).abs() < 1e-12);
+        assert!((l.s - 3.0_f64.sqrt() * var.sqrt() / PI).abs() < 1e-12);
+        // Constant data: zero variance → error
+        assert!(Logistic::fit(&[4.0; 5]).is_err());
+        assert!(Logistic::fit(&[]).is_err());
+    }
+
+    #[test]
+    fn test_logistic_log_likelihood_fast_matches_logpdf_sum() {
+        let l = Logistic::new(0.3, 2.5).unwrap();
+        let data = vec![-20.0, -1.0, 0.3, 4.0, 30.0];
+        let expected: f64 = data.iter().map(|&x| l.logpdf(x).unwrap()).sum();
+        assert!((l.log_likelihood_fast(&data) - expected).abs() < 1e-10);
+        assert!((l.log_likelihood(&data).unwrap() - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_logistic_invalid_params() {
+        assert!(Logistic::new(f64::NAN, 1.0).is_err());
+        assert!(Logistic::new(0.0, f64::NAN).is_err());
+        assert!(Logistic::new(f64::INFINITY, 1.0).is_err());
+        assert!(Logistic::new(0.0, 0.0).is_err());
+        assert!(Logistic::new(0.0, -1.0).is_err());
+    }
+}

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -65,6 +65,7 @@ use crate::error::{StatsError, StatsResult};
 /// assert!((ln.mean() - 0.5_f64.exp()).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LogNormal {
     /// Location (mean of ln X) μ
     pub mu: f64,
@@ -75,6 +76,13 @@ pub struct LogNormal {
 impl LogNormal {
     /// Creates a `LogNormal(μ, σ)` distribution.
     pub fn new(mu: f64, sigma: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !mu.is_finite() || !sigma.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "LogNormal::new: parameters must be finite".to_string(),
+            });
+        }
         if sigma <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "LogNormal::new: sigma must be positive".to_string(),

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -161,6 +161,13 @@ impl Distribution for LogNormal {
         crate::prob::erfc(z).map(|e| 0.5 * e)
     }
 
+    /// Ziggurat-based sampling: `X = exp(μ + σ·Z)` with `Z` from the
+    /// Normal ziggurat — much faster than the default inverse-CDF path.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        let z = crate::distributions::normal_distribution::ziggurat_standard_normal(rng);
+        Ok((self.mu + self.sigma * z).exp())
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {
             return Err(StatsError::InvalidInput {

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -77,7 +77,7 @@ impl LogNormal {
     /// Creates a `LogNormal(μ, σ)` distribution.
     pub fn new(mu: f64, sigma: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !mu.is_finite() || !sigma.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "LogNormal::new: parameters must be finite".to_string(),

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -144,6 +144,14 @@ impl Distribution for LogNormal {
         }
         normal_cdf(x.ln(), self.mu, self.sigma)
     }
+    /// Exact tail: `S(x) = erfc((ln x − μ)/(σ√2))/2`.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= 0.0 {
+            return Ok(1.0);
+        }
+        let z = (x.ln() - self.mu) / (self.sigma * std::f64::consts::SQRT_2);
+        crate::prob::erfc(z).map(|e| 0.5 * e)
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -30,25 +30,23 @@ pub mod traits;
 
 // ── Flat re-exports for ergonomic imports ──────────────────────────────────────
 // Allows `use rs_stats::distributions::Weibull` instead of the full module path.
-// Continuous — existing
-pub use binomial_distribution::Binomial;
-pub use exponential_distribution::Exponential;
-pub use multivariate_normal::MultivariateNormal;
-pub use normal_distribution::Normal;
-pub use poisson_distribution::Poisson;
-pub use uniform_distribution::Uniform;
-// Continuous — new
 pub use beta::Beta;
+pub use binomial_distribution::Binomial;
 pub use cauchy::Cauchy;
 pub use chi_squared::ChiSquared;
+pub use exponential_distribution::Exponential;
 pub use f_distribution::FDistribution;
 pub use gamma_distribution::Gamma;
 pub use laplace::Laplace;
 pub use logistic::Logistic;
 pub use lognormal::LogNormal;
+pub use multivariate_normal::MultivariateNormal;
+pub use normal_distribution::Normal;
 pub use pareto::Pareto;
+pub use poisson_distribution::Poisson;
 pub use student_t::StudentT;
+pub use uniform_distribution::Uniform;
 pub use weibull::Weibull;
-// Discrete — new
+// Discrete
 pub use geometric::Geometric;
 pub use negative_binomial::NegativeBinomial;

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -7,10 +7,14 @@ pub mod uniform_distribution;
 
 // ── New continuous distributions ───────────────────────────────────────────────
 pub mod beta;
+pub mod cauchy;
 pub mod chi_squared;
 pub mod f_distribution;
 pub mod gamma_distribution;
+pub mod laplace;
+pub mod logistic;
 pub mod lognormal;
+pub mod pareto;
 pub mod student_t;
 pub mod weibull;
 
@@ -19,6 +23,8 @@ pub mod geometric;
 pub mod negative_binomial;
 
 // ── Traits & fitting ───────────────────────────────────────────────────────────
+pub mod multivariate_normal;
+
 pub mod fitting;
 pub mod traits;
 
@@ -27,15 +33,20 @@ pub mod traits;
 // Continuous — existing
 pub use binomial_distribution::Binomial;
 pub use exponential_distribution::Exponential;
+pub use multivariate_normal::MultivariateNormal;
 pub use normal_distribution::Normal;
 pub use poisson_distribution::Poisson;
 pub use uniform_distribution::Uniform;
 // Continuous — new
 pub use beta::Beta;
+pub use cauchy::Cauchy;
 pub use chi_squared::ChiSquared;
 pub use f_distribution::FDistribution;
 pub use gamma_distribution::Gamma;
+pub use laplace::Laplace;
+pub use logistic::Logistic;
 pub use lognormal::LogNormal;
+pub use pareto::Pareto;
 pub use student_t::StudentT;
 pub use weibull::Weibull;
 // Discrete — new

--- a/src/distributions/multivariate_normal.rs
+++ b/src/distributions/multivariate_normal.rs
@@ -1,0 +1,259 @@
+//! # Multivariate Normal distribution
+//!
+//! `N(μ, Σ)` over `ℝᵈ`, with flat row-major covariance storage (like the
+//! rest of `utils::linalg`). The constructor Cholesky-factorises Σ once —
+//! validating positive-definiteness in the process — so `logpdf` is a
+//! Mahalanobis form and `sample` a single triangular solve (`μ + L·z`).
+//!
+//! Not part of the scalar [`Distribution`](crate::Distribution) trait
+//! (its support type is a vector); it exposes the same vocabulary as a
+//! standalone struct.
+//!
+//! ```
+//! use rs_stats::distributions::multivariate_normal::MultivariateNormal;
+//! use rand::SeedableRng;
+//!
+//! let mvn = MultivariateNormal::new(
+//!     vec![1.0, -2.0],
+//!     vec![2.0, 0.5,
+//!          0.5, 1.5],
+//! ).unwrap();
+//! let lp = mvn.logpdf(&[1.0, -2.0]).unwrap(); // density at the mean
+//! let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+//! let draw = mvn.sample(&mut rng).unwrap();   // Vec<f64> of dim 2
+//! assert_eq!(draw.len(), 2);
+//! assert!(lp.is_finite());
+//! ```
+
+use crate::distributions::normal_distribution::ziggurat_standard_normal;
+use crate::error::{StatsError, StatsResult};
+use crate::utils::constants::LN_2PI;
+use crate::utils::linalg::{cholesky, invert, mahalanobis_sq};
+
+/// Multivariate Normal `N(μ, Σ)` with precomputed Cholesky factor and
+/// precision matrix.
+#[derive(Debug, Clone)]
+pub struct MultivariateNormal {
+    mean: Vec<f64>,
+    cov: Vec<f64>,
+    dim: usize,
+    /// Lower-triangular L with Σ = L·Lᵀ (row-major).
+    chol: Vec<f64>,
+    /// Σ⁻¹ (row-major).
+    cov_inv: Vec<f64>,
+    /// −½·(d·ln 2π + ln|Σ|).
+    log_norm: f64,
+}
+
+impl MultivariateNormal {
+    /// Build from a mean vector and a **row-major** `d×d` covariance
+    /// matrix. Validates symmetry, finiteness and positive-definiteness
+    /// (via Cholesky).
+    pub fn new(mean: Vec<f64>, cov: Vec<f64>) -> StatsResult<Self> {
+        let dim = mean.len();
+        if dim == 0 {
+            return Err(StatsError::invalid_input(
+                "MultivariateNormal::new: mean must not be empty",
+            ));
+        }
+        if cov.len() != dim * dim {
+            return Err(StatsError::invalid_input(format!(
+                "MultivariateNormal::new: covariance must be {dim}×{dim} (row-major), got {} elements",
+                cov.len()
+            )));
+        }
+        if mean.iter().chain(cov.iter()).any(|v| !v.is_finite()) {
+            return Err(StatsError::invalid_input(
+                "MultivariateNormal::new: parameters must be finite",
+            ));
+        }
+        for i in 0..dim {
+            for j in (i + 1)..dim {
+                let (a, b) = (cov[i * dim + j], cov[j * dim + i]);
+                if (a - b).abs() > 1e-9 * a.abs().max(b.abs()).max(1.0) {
+                    return Err(StatsError::invalid_input(format!(
+                        "MultivariateNormal::new: covariance is not symmetric at ({i}, {j})"
+                    )));
+                }
+            }
+        }
+
+        let chol = cholesky(&cov, dim)?; // SPD check happens here
+        let cov_inv = invert(&cov, dim, 1e-12)?;
+        // ln|Σ| = 2·Σᵢ ln Lᵢᵢ — exact and cheap from the factor.
+        let log_det: f64 = (0..dim).map(|i| chol[i * dim + i].ln()).sum::<f64>() * 2.0;
+        let log_norm = -0.5 * (dim as f64 * LN_2PI + log_det);
+
+        Ok(Self {
+            mean,
+            cov,
+            dim,
+            chol,
+            cov_inv,
+            log_norm,
+        })
+    }
+
+    /// Dimension `d`.
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Mean vector μ.
+    pub fn mean(&self) -> &[f64] {
+        &self.mean
+    }
+
+    /// Covariance matrix Σ (row-major).
+    pub fn covariance(&self) -> &[f64] {
+        &self.cov
+    }
+
+    /// Log-density at `x`:
+    /// `−½·(d·ln 2π + ln|Σ| + (x−μ)ᵀΣ⁻¹(x−μ))`.
+    pub fn logpdf(&self, x: &[f64]) -> StatsResult<f64> {
+        if x.len() != self.dim {
+            return Err(StatsError::dimension_mismatch(format!(
+                "MultivariateNormal::logpdf: expected dim {}, got {}",
+                self.dim,
+                x.len()
+            )));
+        }
+        let d2 = mahalanobis_sq(x, &self.mean, &self.cov_inv)?;
+        Ok(self.log_norm - 0.5 * d2)
+    }
+
+    /// Density at `x`.
+    pub fn pdf(&self, x: &[f64]) -> StatsResult<f64> {
+        Ok(self.logpdf(x)?.exp())
+    }
+
+    /// Squared Mahalanobis distance of `x` to the mean — distributed as
+    /// χ²(d) under the model (the classic multivariate outlier score).
+    pub fn mahalanobis_squared(&self, x: &[f64]) -> StatsResult<f64> {
+        mahalanobis_sq(x, &self.mean, &self.cov_inv)
+    }
+
+    /// One draw: `μ + L·z` with `z` i.i.d. standard normal (ziggurat).
+    pub fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<Vec<f64>> {
+        let z: Vec<f64> = (0..self.dim)
+            .map(|_| ziggurat_standard_normal(rng))
+            .collect();
+        let mut out = self.mean.clone();
+        for i in 0..self.dim {
+            let row = &self.chol[i * self.dim..i * self.dim + i + 1];
+            out[i] += row.iter().zip(&z).map(|(l, zi)| l * zi).sum::<f64>();
+        }
+        Ok(out)
+    }
+
+    /// `n` draws, one `Vec` per row.
+    pub fn sample_n(&self, rng: &mut dyn rand::RngCore, n: usize) -> StatsResult<Vec<Vec<f64>>> {
+        (0..n).map(|_| self.sample(rng)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    fn mvn3() -> MultivariateNormal {
+        MultivariateNormal::new(
+            vec![1.0, -2.0, 0.5],
+            vec![
+                2.0, 0.5, 0.3, //
+                0.5, 1.5, -0.2, //
+                0.3, -0.2, 1.0,
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_logpdf_matches_scipy() {
+        // Reference: scipy.stats.multivariate_normal.logpdf.
+        let m = mvn3();
+        for (x, expected) in [
+            (vec![1.0, -2.0, 0.5], -3.209935797624346),
+            (vec![0.0, 0.0, 0.0], -5.306400444088994),
+            (vec![3.0, -4.0, 2.0], -6.7548852925738405),
+        ] {
+            let got = m.logpdf(&x).unwrap();
+            assert!((got - expected).abs() < 1e-10, "logpdf({x:?}) = {got}");
+        }
+    }
+
+    #[test]
+    fn test_cholesky_factor_matches_numpy() {
+        let m = mvn3();
+        let expected = [
+            std::f64::consts::SQRT_2, // √cov[0][0] = √2
+            0.0,
+            0.0, //
+            0.35355339059327373,
+            1.1726039399558574,
+            0.0, //
+            0.21213203435596423,
+            -0.23452078799117143,
+            0.9486832980505138,
+        ];
+        for (a, b) in m.chol.iter().zip(expected) {
+            assert!((a - b).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn test_sample_moments() {
+        let m = mvn3();
+        let mut rng = ChaCha8Rng::seed_from_u64(2026);
+        let n = 60_000usize;
+        let draws = m.sample_n(&mut rng, n).unwrap();
+
+        // Empirical mean and covariance vs the parameters (~6σ bounds).
+        let nf = n as f64;
+        let mut mean = [0.0_f64; 3];
+        for d in &draws {
+            for i in 0..3 {
+                mean[i] += d[i];
+            }
+        }
+        for v in mean.iter_mut() {
+            *v /= nf;
+        }
+        for i in 0..3 {
+            assert!(
+                (mean[i] - m.mean[i]).abs() < 0.04,
+                "mean[{i}] = {}",
+                mean[i]
+            );
+        }
+        for i in 0..3 {
+            for j in 0..3 {
+                let c: f64 = draws
+                    .iter()
+                    .map(|d| (d[i] - mean[i]) * (d[j] - mean[j]))
+                    .sum::<f64>()
+                    / (nf - 1.0);
+                assert!(
+                    (c - m.cov[i * 3 + j]).abs() < 0.06,
+                    "cov[{i}][{j}] = {c} vs {}",
+                    m.cov[i * 3 + j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_validation_errors() {
+        // Not symmetric.
+        assert!(MultivariateNormal::new(vec![0.0, 0.0], vec![1.0, 0.5, 0.1, 1.0]).is_err());
+        // Not positive-definite.
+        assert!(MultivariateNormal::new(vec![0.0, 0.0], vec![1.0, 2.0, 2.0, 1.0]).is_err());
+        // Dimension mismatch.
+        assert!(MultivariateNormal::new(vec![0.0, 0.0], vec![1.0; 3]).is_err());
+        let m = mvn3();
+        assert!(m.logpdf(&[0.0, 0.0]).is_err());
+    }
+}

--- a/src/distributions/negative_binomial.rs
+++ b/src/distributions/negative_binomial.rs
@@ -40,7 +40,7 @@
 //! ```
 
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::ln_gamma;
+use crate::utils::special_functions::{ln_gamma, regularized_incomplete_beta};
 use serde::{Deserialize, Serialize};
 
 /// Negative Binomial distribution NegBinom(r, p).
@@ -128,17 +128,30 @@ impl crate::distributions::traits::Distribution for NegativeBinomial {
         Ok(log_binom + self.r * self.p.ln() + kf * (1.0 - self.p).ln())
     }
 
-    fn cdf(&self, k: u64) -> StatsResult<f64> {
-        // Sum PMF from 0 to k
-        let mut sum = 0.0_f64;
-        for i in 0..=k {
-            sum += self.pmf(i)?;
-            // Early exit if essentially 1
-            if sum >= 1.0 - 1e-15 {
-                return Ok(1.0);
-            }
+    fn log_likelihood(&self, data: &[u64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[u64]) -> f64 {
+        // ln Γ(r) and r·ln p / ln(1−p) only depend on the parameters —
+        // hoisted, each point costs 2 ln_gamma instead of 3 + 2 ln.
+        let log_norm = self.r * self.p.ln() - ln_gamma(self.r);
+        let ln_q = (1.0 - self.p).ln();
+        let mut acc = 0.0_f64;
+        for &k in data {
+            let kf = k as f64;
+            acc += ln_gamma(kf + self.r) - ln_gamma(kf + 1.0) + kf * ln_q;
         }
-        Ok(sum.clamp(0.0, 1.0))
+        data.len() as f64 * log_norm + acc
+    }
+
+    fn cdf(&self, k: u64) -> StatsResult<f64> {
+        // Closed form: P(X ≤ k) = I_p(r, k+1), the regularized incomplete
+        // beta. O(1) instead of the previous O(k) PMF sum (3 ln_gamma + exp
+        // per term) — which also made inverse_cdf O(k log k).
+        Ok(
+            regularized_incomplete_beta(self.r, k as f64 + 1.0, self.p).clamp(0.0, 1.0),
+        )
     }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {

--- a/src/distributions/negative_binomial.rs
+++ b/src/distributions/negative_binomial.rs
@@ -158,15 +158,11 @@ impl crate::distributions::traits::Distribution for NegativeBinomial {
         // Closed form: P(X ≤ k) = I_p(r, k+1), the regularized incomplete
         // beta. O(1) instead of the previous O(k) PMF sum (3 ln_gamma + exp
         // per term) — which also made inverse_cdf O(k log k).
-        Ok(
-            regularized_incomplete_beta(self.r, k as f64 + 1.0, self.p).clamp(0.0, 1.0),
-        )
+        Ok(regularized_incomplete_beta(self.r, k as f64 + 1.0, self.p).clamp(0.0, 1.0))
     }
     /// Exact tail via `1 − I_p(r, k+1) = I_{1−p}(k+1, r)`.
     fn sf(&self, k: u64) -> StatsResult<f64> {
-        Ok(
-            regularized_incomplete_beta(k as f64 + 1.0, self.r, 1.0 - self.p).clamp(0.0, 1.0),
-        )
+        Ok(regularized_incomplete_beta(k as f64 + 1.0, self.r, 1.0 - self.p).clamp(0.0, 1.0))
     }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {

--- a/src/distributions/negative_binomial.rs
+++ b/src/distributions/negative_binomial.rs
@@ -153,6 +153,12 @@ impl crate::distributions::traits::Distribution for NegativeBinomial {
             regularized_incomplete_beta(self.r, k as f64 + 1.0, self.p).clamp(0.0, 1.0),
         )
     }
+    /// Exact tail via `1 − I_p(r, k+1) = I_{1−p}(k+1, r)`.
+    fn sf(&self, k: u64) -> StatsResult<f64> {
+        Ok(
+            regularized_incomplete_beta(k as f64 + 1.0, self.r, 1.0 - self.p).clamp(0.0, 1.0),
+        )
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
         crate::distributions::traits::discrete_inverse_cdf_search(p, |k| self.cdf(k))

--- a/src/distributions/negative_binomial.rs
+++ b/src/distributions/negative_binomial.rs
@@ -165,6 +165,20 @@ impl crate::distributions::traits::Distribution for NegativeBinomial {
         Ok(regularized_incomplete_beta(k as f64 + 1.0, self.r, 1.0 - self.p).clamp(0.0, 1.0))
     }
 
+    /// Direct sampling via the Gamma-Poisson mixture:
+    /// `K ~ Poisson(Λ)` with `Λ ~ Gamma(r, scale = (1−p)/p)` is exactly
+    /// `NegBinom(r, p)` — two direct draws, no quantile search.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<u64> {
+        use crate::distributions::gamma_distribution::gamma_sample_unit_rate;
+        use crate::distributions::poisson_distribution::poisson_sample;
+        let lambda = gamma_sample_unit_rate(rng, self.r) * (1.0 - self.p) / self.p;
+        if lambda <= 0.0 {
+            // Γ draw can underflow to 0 for tiny r: Poisson(0) ≡ 0.
+            return Ok(0);
+        }
+        Ok(poisson_sample(rng, lambda))
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
         crate::distributions::traits::discrete_inverse_cdf_search(p, |k| self.cdf(k))
     }

--- a/src/distributions/negative_binomial.rs
+++ b/src/distributions/negative_binomial.rs
@@ -41,6 +41,7 @@
 
 use crate::error::{StatsError, StatsResult};
 use crate::utils::special_functions::{ln_gamma, regularized_incomplete_beta};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Negative Binomial distribution NegBinom(r, p).
@@ -53,7 +54,8 @@ use serde::{Deserialize, Serialize};
 /// let nb = NegativeBinomial::new(5.0, 0.5).unwrap();
 /// assert!((nb.mean() - 5.0).abs() < 1e-10);
 /// ```
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NegativeBinomial {
     /// Number of successes r > 0 (can be non-integer, i.e. the overdispersion parameter)
     pub r: f64,
@@ -64,6 +66,13 @@ pub struct NegativeBinomial {
 impl NegativeBinomial {
     /// Creates a `NegBinom(r, p)` distribution.
     pub fn new(r: f64, p: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !r.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "NegativeBinomial::new: parameters must be finite".to_string(),
+            });
+        }
         if r <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "NegativeBinomial::new: r must be positive".to_string(),

--- a/src/distributions/negative_binomial.rs
+++ b/src/distributions/negative_binomial.rs
@@ -67,7 +67,7 @@ impl NegativeBinomial {
     /// Creates a `NegBinom(r, p)` distribution.
     pub fn new(r: f64, p: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !r.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "NegativeBinomial::new: parameters must be finite".to_string(),

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -292,6 +292,12 @@ impl Distribution for Normal {
     fn cdf(&self, x: f64) -> StatsResult<f64> {
         normal_cdf(x, self.mean, self.std_dev)
     }
+    /// Exact upper tail: `S(x) = erfc(z/√2)/2` — full relative precision
+    /// where `1 − cdf` would round to 0.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        let z = (x - self.mean) / (self.std_dev * SQRT_2);
+        erfc(z).map(|e| 0.5 * e)
+    }
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         normal_inverse_cdf(p, self.mean, self.std_dev)
     }

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -201,6 +201,95 @@ pub(crate) fn normal_inverse_cdf(p: f64, mean: f64, std_dev: f64) -> StatsResult
     Ok(mean + std_dev * z)
 }
 
+// ── Ziggurat sampling (Marsaglia & Tsang, 2000) ────────────────────────────────
+
+/// Rightmost layer boundary x₁ for 128 layers.
+const ZIG_R: f64 = 3.442619855899;
+/// Area of each layer (and of the base strip + tail).
+const ZIG_V: f64 = 9.91256303526217e-3;
+/// 2³¹ — scale between the signed 32-bit draw and the x tables.
+const ZIG_M1: f64 = 2147483648.0;
+
+struct ZigguratTables {
+    /// Acceptance thresholds: |hz| < k[i] ⇒ hz·w[i] is inside layer i.
+    k: [u32; 128],
+    /// x[i] / 2³¹ — converts the integer draw to a coordinate.
+    w: [f64; 128],
+    /// f(x[i]) = exp(−x[i]²/2) — layer ordinates for the wedge test.
+    f: [f64; 128],
+}
+
+static ZIG: std::sync::LazyLock<ZigguratTables> = std::sync::LazyLock::new(|| {
+    let mut k = [0u32; 128];
+    let mut w = [0.0f64; 128];
+    let mut f = [0.0f64; 128];
+
+    let mut dn = ZIG_R;
+    let mut tn = dn;
+    let q = ZIG_V / (-0.5 * dn * dn).exp();
+
+    k[0] = ((dn / q) * ZIG_M1) as u32;
+    k[1] = 0;
+    w[0] = q / ZIG_M1;
+    w[127] = dn / ZIG_M1;
+    f[0] = 1.0;
+    f[127] = (-0.5 * dn * dn).exp();
+
+    for i in (1..=126).rev() {
+        dn = (-2.0 * (ZIG_V / dn + (-0.5 * dn * dn).exp()).ln()).sqrt();
+        k[i + 1] = ((dn / tn) * ZIG_M1) as u32;
+        tn = dn;
+        f[i] = (-0.5 * dn * dn).exp();
+        w[i] = dn / ZIG_M1;
+    }
+
+    ZigguratTables { k, w, f }
+});
+
+/// Uniform draw in (0, 1] — never 0, so `ln` stays finite.
+#[inline]
+fn uniform01(rng: &mut dyn rand::RngCore) -> f64 {
+    ((rng.next_u64() >> 11) + 1) as f64 * (1.0 / (1u64 << 53) as f64)
+}
+
+/// One standard-normal draw via the 128-layer ziggurat.
+///
+/// ~99% of draws cost one `next_u64`, one table compare and one multiply —
+/// no `ln`/`exp`/`sqrt` — vs the ~4 transcendentals of inverse-CDF
+/// sampling. The layer index and the 32-bit magnitude come from disjoint
+/// bits of the same `u64`, so they are independent.
+pub(crate) fn ziggurat_standard_normal(rng: &mut dyn rand::RngCore) -> f64 {
+    let zig = &*ZIG;
+    loop {
+        let bits = rng.next_u64();
+        let iz = (bits & 127) as usize;
+        let hz = (bits >> 32) as u32 as i32;
+
+        // Fast path: strictly inside layer iz.
+        if (hz.unsigned_abs()) < zig.k[iz] {
+            return hz as f64 * zig.w[iz];
+        }
+
+        if iz == 0 {
+            // Base strip: sample the tail beyond R by Marsaglia's method.
+            loop {
+                let x = -uniform01(rng).ln() / ZIG_R;
+                let y = -uniform01(rng).ln();
+                if y + y >= x * x {
+                    return if hz >= 0 { ZIG_R + x } else { -(ZIG_R + x) };
+                }
+            }
+        }
+
+        // Wedge: accept with probability proportional to the density gap.
+        let x = hz as f64 * zig.w[iz];
+        if zig.f[iz] + uniform01(rng) * (zig.f[iz - 1] - zig.f[iz]) < (-0.5 * x * x).exp() {
+            return x;
+        }
+        // Rejected: redraw from scratch.
+    }
+}
+
 // ── Typed struct + Distribution impl ──────────────────────────────────────────
 
 /// Normal (Gaussian) distribution N(μ, σ²) as a typed struct.
@@ -254,16 +343,39 @@ impl Normal {
                 message: "Normal::fit: data must not be empty".to_string(),
             });
         }
-        let mut count = 0.0_f64;
-        let mut mean = 0.0_f64;
-        let mut m2 = 0.0_f64;
-        for &x in data {
-            count += 1.0;
-            let delta = x - mean;
-            mean += delta / count;
-            m2 += delta * (x - mean);
+        // Two-pass, multi-accumulator estimator. The textbook two-pass
+        // (mean first, then Σ(x−x̄)²) is just as numerically stable as
+        // Welford, but Welford's update is a serial dependency chain —
+        // it can't pipeline or vectorise. Four independent lanes per pass
+        // let LLVM vectorise both reductions (~6× on 100k points).
+        let n = data.len() as f64;
+        let mut acc = [0.0_f64; 4];
+        let mut chunks = data.chunks_exact(4);
+        for c in chunks.by_ref() {
+            for lane in 0..4 {
+                acc[lane] += c[lane];
+            }
         }
-        let variance = m2 / count; // population (MLE)
+        let mut sum = (acc[0] + acc[1]) + (acc[2] + acc[3]);
+        for &x in chunks.remainder() {
+            sum += x;
+        }
+        let mean = sum / n;
+
+        let mut acc = [0.0_f64; 4];
+        let mut chunks = data.chunks_exact(4);
+        for c in chunks.by_ref() {
+            for lane in 0..4 {
+                let d = c[lane] - mean;
+                acc[lane] += d * d;
+            }
+        }
+        let mut m2 = (acc[0] + acc[1]) + (acc[2] + acc[3]);
+        for &x in chunks.remainder() {
+            let d = x - mean;
+            m2 += d * d;
+        }
+        let variance = m2 / n; // population (MLE)
         Self::new(mean, variance.sqrt())
     }
 }
@@ -317,6 +429,12 @@ impl Distribution for Normal {
         let z = (x - self.mean) / (self.std_dev * SQRT_2);
         erfc(z).map(|e| 0.5 * e)
     }
+    /// Ziggurat sampling (Marsaglia-Tsang): ~8× faster than the default
+    /// inverse-CDF path — one u64 draw + one multiply for ~99% of samples.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        Ok(self.mean + self.std_dev * ziggurat_standard_normal(rng))
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         normal_inverse_cdf(p, self.mean, self.std_dev)
     }
@@ -334,6 +452,41 @@ mod tests {
 
     // Small epsilon for floating-point comparisons
     const EPSILON: f64 = 1e-7;
+
+    #[test]
+    fn test_ziggurat_moments_and_ks() {
+        use rand::SeedableRng;
+        let d = Normal::new(0.0, 1.0).unwrap();
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(99);
+        let n = 200_000usize;
+        let xs = d.sample_n(&mut rng, n).unwrap();
+
+        let nf = n as f64;
+        let mean = xs.iter().sum::<f64>() / nf;
+        let m2 = xs.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / nf;
+        let m3 = xs.iter().map(|x| (x - mean).powi(3)).sum::<f64>() / nf;
+        let m4 = xs.iter().map(|x| (x - mean).powi(4)).sum::<f64>() / nf;
+        let skew = m3 / m2.powf(1.5);
+        let kurt = m4 / (m2 * m2) - 3.0;
+
+        // ~6σ estimator bounds at n = 200k.
+        assert!(mean.abs() < 0.014, "mean = {mean}");
+        assert!((m2 - 1.0).abs() < 0.02, "var = {m2}");
+        assert!(skew.abs() < 0.033, "skew = {skew}");
+        assert!(kurt.abs() < 0.066, "kurtosis = {kurt}");
+
+        // Tail sanity: the ziggurat's rejection tail must populate |x| > R.
+        let beyond_r = xs.iter().filter(|x| x.abs() > 3.442619855899).count();
+        let expected = 2.0 * 0.5 * crate::prob::erfc(3.442619855899 / SQRT_2).unwrap() * nf;
+        assert!(
+            (beyond_r as f64 - expected).abs() < 6.0 * expected.sqrt(),
+            "tail count {beyond_r} vs expected {expected:.0}"
+        );
+
+        // Distribution-level check.
+        let ks = crate::distributions::fitting::ks_test(&xs, |x| d.cdf(x).unwrap());
+        assert!(ks.p_value > 1e-3, "KS p = {}", ks.p_value);
+    }
 
     #[test]
     fn test_normal_pdf_standard() {

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -229,7 +229,7 @@ impl Normal {
     /// Creates a `Normal` distribution with validation.
     pub fn new(mean: f64, std_dev: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !mean.is_finite() || !std_dev.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Normal::new: parameters must be finite".to_string(),
@@ -288,9 +288,20 @@ impl Distribution for Normal {
     ///
     /// `Σ ln f(xᵢ) = −½ · Σ ((xᵢ−μ)/σ)² − n·(ln σ + ½·ln 2π)`
     fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // Pure-arithmetic kernel: four independent accumulators break the
+        // FP-add dependency chain so the loop pipelines/vectorises (see
+        // prob::average for the rationale).
         let inv_sigma = 1.0 / self.std_dev;
-        let mut sum_sq = 0.0_f64;
-        for &x in data {
+        let mut acc = [0.0_f64; 4];
+        let mut chunks = data.chunks_exact(4);
+        for chunk in chunks.by_ref() {
+            for lane in 0..4 {
+                let z = (chunk[lane] - self.mean) * inv_sigma;
+                acc[lane] += z * z;
+            }
+        }
+        let mut sum_sq = (acc[0] + acc[1]) + (acc[2] + acc[3]);
+        for &x in chunks.remainder() {
             let z = (x - self.mean) * inv_sigma;
             sum_sq += z * z;
         }

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -217,6 +217,7 @@ pub(crate) fn normal_inverse_cdf(p: f64, mean: f64, std_dev: f64) -> StatsResult
 /// assert!((n.pdf(0.0).unwrap() - 0.398_942_280_401_4).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Normal {
     /// Mean μ
     pub mean: f64,
@@ -227,6 +228,13 @@ pub struct Normal {
 impl Normal {
     /// Creates a `Normal` distribution with validation.
     pub fn new(mean: f64, std_dev: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !mean.is_finite() || !std_dev.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Normal::new: parameters must be finite".to_string(),
+            });
+        }
         if std_dev <= 0.0 || std_dev.is_nan() || mean.is_nan() {
             return Err(StatsError::InvalidInput {
                 message: "Normal::new: std_dev must be positive and parameters must be finite"

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -46,7 +46,7 @@
 
 use crate::distributions::traits::Distribution;
 use crate::error::{StatsError, StatsResult};
-use crate::prob::erf;
+use crate::prob::erfc;
 use crate::utils::constants::{INV_SQRT_2PI, SQRT_2};
 
 // Private math helpers; the public API is the [`Normal`] struct's
@@ -103,8 +103,10 @@ pub(crate) fn normal_cdf(x: f64, mean: f64, std_dev: f64) -> StatsResult<f64> {
     if x == mean {
         return Ok(0.5);
     }
+    // Φ(x) = erfc(−z)/2 keeps full relative precision in the lower tail,
+    // where 0.5·(1 + erf(z)) collapses to 0 (erf(z) → −1 exactly).
     let z = (x - mean) / (std_dev * SQRT_2);
-    Ok(0.5 * (1.0 + erf(z)?))
+    Ok(0.5 * erfc(-z)?)
 }
 
 /// Calculates the inverse cumulative distribution function (Quantile function) for the normal distribution.

--- a/src/distributions/normal_distribution.rs
+++ b/src/distributions/normal_distribution.rs
@@ -248,7 +248,7 @@ static ZIG: std::sync::LazyLock<ZigguratTables> = std::sync::LazyLock::new(|| {
 
 /// Uniform draw in (0, 1] — never 0, so `ln` stays finite.
 #[inline]
-fn uniform01(rng: &mut dyn rand::RngCore) -> f64 {
+pub(crate) fn uniform01(rng: &mut dyn rand::RngCore) -> f64 {
     ((rng.next_u64() >> 11) + 1) as f64 * (1.0 / (1u64 << 53) as f64)
 }
 

--- a/src/distributions/pareto.rs
+++ b/src/distributions/pareto.rs
@@ -1,0 +1,308 @@
+//! # Pareto Distribution (Type I)
+//!
+//! The Pareto(xₘ, α) distribution is the canonical power-law distribution:
+//! "80/20 rule" phenomena where a small fraction of items carries most of the
+//! total (wealth, city sizes, file sizes, insurance claims).
+//!
+//! **PDF**: f(x; xₘ, α) = α·xₘ^α / x^(α+1),  x ≥ xₘ
+//!
+//! **CDF**: F(x) = 1 − (xₘ/x)^α   **SF**: S(x) = (xₘ/x)^α (exact power-law tail)
+//!
+//! **Mean**: α·xₘ/(α − 1) for α > 1 (∞ otherwise)
+//! **Variance**: xₘ²·α / [(α − 1)²(α − 2)] for α > 2 (∞ otherwise)
+//!
+//! ## Applications
+//!
+//! - Income and wealth modeling (Pareto's original use)
+//! - Insurance: large-claim severity
+//! - Network science: degree distributions, file-size distributions
+//!
+//! ## Example
+//!
+//! ```rust
+//! use rs_stats::distributions::pareto::Pareto;
+//! use rs_stats::distributions::traits::Distribution;
+//!
+//! let p = Pareto::new(2.0, 3.0).unwrap();
+//! assert!((p.mean() - 3.0).abs() < 1e-12); // α·xₘ/(α−1) = 3·2/2
+//! assert!((p.sf(5.0).unwrap() - 0.064).abs() < 1e-15); // (2/5)³
+//! ```
+
+use crate::distributions::traits::Distribution;
+use crate::error::{StatsError, StatsResult};
+
+/// Pareto (type I) distribution Pareto(xₘ, α).
+///
+/// # Examples
+/// ```
+/// use rs_stats::distributions::pareto::Pareto;
+/// use rs_stats::distributions::traits::Distribution;
+///
+/// let p = Pareto::new(1.0, 2.5).unwrap();
+/// assert!((p.cdf(1.0).unwrap() - 0.0).abs() < 1e-15); // support starts at xₘ
+/// ```
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Pareto {
+    /// Scale parameter xₘ > 0 (minimum possible value)
+    pub xm: f64,
+    /// Shape parameter α > 0 (tail index)
+    pub alpha: f64,
+}
+
+impl Pareto {
+    /// Creates a `Pareto(xₘ, α)` distribution.
+    pub fn new(xm: f64, alpha: f64) -> StatsResult<Self> {
+        if !xm.is_finite() || !alpha.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Pareto::new: parameters must be finite".to_string(),
+            });
+        }
+        if xm <= 0.0 || alpha <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Pareto::new: xm and alpha must be positive".to_string(),
+            });
+        }
+        Ok(Self { xm, alpha })
+    }
+
+    /// Exact MLE: x̂ₘ = min(data), α̂ = n / Σ ln(xᵢ/x̂ₘ).
+    ///
+    /// Requires all data strictly positive. Errors if the data is constant
+    /// (Σ ln(xᵢ/x̂ₘ) = 0 gives an infinite α̂).
+    pub fn fit(data: &[f64]) -> StatsResult<Self> {
+        if data.is_empty() {
+            return Err(StatsError::InvalidInput {
+                message: "Pareto::fit: data must not be empty".to_string(),
+            });
+        }
+        if data.iter().any(|&x| x <= 0.0) {
+            return Err(StatsError::InvalidInput {
+                message: "Pareto::fit: all data values must be positive".to_string(),
+            });
+        }
+        let xm = data.iter().cloned().fold(f64::INFINITY, f64::min);
+        let sum_ln = data.iter().map(|&x| (x / xm).ln()).sum::<f64>();
+        if sum_ln <= 0.0 {
+            return Err(StatsError::InvalidInput {
+                message: "Pareto::fit: data is constant (alpha estimate diverges)".to_string(),
+            });
+        }
+        Self::new(xm, data.len() as f64 / sum_ln)
+    }
+}
+
+impl Distribution for Pareto {
+    type X = f64;
+    fn name(&self) -> &str {
+        "Pareto"
+    }
+    fn num_params(&self) -> usize {
+        2
+    }
+
+    fn pdf(&self, x: f64) -> StatsResult<f64> {
+        if x < self.xm {
+            return Ok(0.0);
+        }
+        Ok(self.logpdf(x)?.exp())
+    }
+
+    fn logpdf(&self, x: f64) -> StatsResult<f64> {
+        if x < self.xm {
+            return Ok(f64::NEG_INFINITY);
+        }
+        // ln f = ln α + α·ln xₘ − (α + 1)·ln x — stable arbitrarily far in
+        // the tail where the direct power would underflow.
+        Ok(self.alpha.ln() + self.alpha * self.xm.ln() - (self.alpha + 1.0) * x.ln())
+    }
+
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // ln α + α·ln xₘ hoisted out of the loop; one ln per point remains.
+        let log_norm = self.alpha.ln() + self.alpha * self.xm.ln();
+        let a1 = self.alpha + 1.0;
+        let mut acc = 0.0_f64;
+        for &x in data {
+            if x < self.xm {
+                return f64::NEG_INFINITY;
+            }
+            acc -= a1 * x.ln();
+        }
+        data.len() as f64 * log_norm + acc
+    }
+
+    fn cdf(&self, x: f64) -> StatsResult<f64> {
+        if x <= self.xm {
+            return Ok(0.0);
+        }
+        // 1 − (xₘ/x)^α as −expm1(α·ln(xₘ/x)): keeps relative precision for
+        // x barely above xₘ where the power is ≈ 1.
+        Ok(-(self.alpha * (self.xm / x).ln()).exp_m1())
+    }
+
+    /// Exact power-law tail: `S(x) = (xₘ/x)^α` — full relative precision
+    /// arbitrarily deep in the tail (never computed as 1 − cdf).
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= self.xm {
+            return Ok(1.0);
+        }
+        Ok((self.xm / x).powf(self.alpha))
+    }
+
+    fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
+        if !(0.0..=1.0).contains(&p) {
+            return Err(StatsError::InvalidInput {
+                message: "Pareto::inverse_cdf: p must be in [0, 1]".to_string(),
+            });
+        }
+        if p == 0.0 {
+            return Ok(self.xm);
+        }
+        if p == 1.0 {
+            return Ok(f64::INFINITY);
+        }
+        // Closed form x = xₘ·(1 − p)^(−1/α) = xₘ·exp(−ln(1 − p)/α), with
+        // ln(1 − p) via ln_1p(−p) so p's low bits survive for p → 0.
+        Ok(self.xm * (-(-p).ln_1p() / self.alpha).exp())
+    }
+
+    /// `α·xₘ/(α − 1)` for α > 1; `f64::INFINITY` otherwise.
+    fn mean(&self) -> f64 {
+        if self.alpha > 1.0 {
+            self.alpha * self.xm / (self.alpha - 1.0)
+        } else {
+            f64::INFINITY
+        }
+    }
+
+    /// `xₘ²·α / [(α − 1)²(α − 2)]` for α > 2; `f64::INFINITY` otherwise.
+    fn variance(&self) -> f64 {
+        if self.alpha > 2.0 {
+            let am1 = self.alpha - 1.0;
+            self.xm * self.xm * self.alpha / (am1 * am1 * (self.alpha - 2.0))
+        } else {
+            f64::INFINITY
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.pareto(b=3, scale=2)  (b = α, scale = xₘ).
+    const TOL: f64 = 1e-12;
+
+    #[test]
+    fn test_pareto_pdf_vs_scipy() {
+        let p = Pareto::new(2.0, 3.0).unwrap();
+        assert!((p.pdf(5.0).unwrap() - 0.038400000000000004).abs() < TOL);
+        assert!((p.logpdf(5.0).unwrap() - (-3.259697819388456)).abs() < TOL);
+        // At the support boundary: pdf(xₘ) = α/xₘ
+        assert!((p.pdf(2.0).unwrap() - 1.5).abs() < TOL);
+        // Below support
+        assert_eq!(p.pdf(1.0).unwrap(), 0.0);
+        assert_eq!(p.logpdf(1.0).unwrap(), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_pareto_cdf_sf_vs_scipy() {
+        let p = Pareto::new(2.0, 3.0).unwrap();
+        assert!((p.cdf(5.0).unwrap() - 0.9359999999999999).abs() < TOL);
+        assert!((p.sf(5.0).unwrap() - 0.064).abs() < TOL);
+        assert_eq!(p.cdf(2.0).unwrap(), 0.0);
+        assert_eq!(p.sf(2.0).unwrap(), 1.0);
+        assert_eq!(p.cdf(0.5).unwrap(), 0.0);
+        assert_eq!(p.sf(0.5).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_pareto_deep_tail_sf() {
+        let p = Pareto::new(2.0, 3.0).unwrap();
+        // scipy: pareto(3, scale=2).sf(1e5) = 8e-15
+        let s = p.sf(1e5).unwrap();
+        assert!((s / 8e-15 - 1.0).abs() < 1e-12, "sf(1e5) = {s}");
+    }
+
+    #[test]
+    fn test_pareto_inverse_cdf_vs_scipy() {
+        let p = Pareto::new(2.0, 3.0).unwrap();
+        assert!((p.inverse_cdf(0.7).unwrap() - 2.987603164371443).abs() < TOL);
+        assert_eq!(p.inverse_cdf(0.0).unwrap(), 2.0);
+        assert_eq!(p.inverse_cdf(1.0).unwrap(), f64::INFINITY);
+        assert!(p.inverse_cdf(-0.1).is_err());
+        assert!(p.inverse_cdf(1.1).is_err());
+    }
+
+    #[test]
+    fn test_pareto_roundtrip() {
+        let p = Pareto::new(0.5, 1.7).unwrap();
+        for &x in &[0.500001, 0.6, 1.0, 10.0, 1e4] {
+            let q = p.cdf(x).unwrap();
+            let x_back = p.inverse_cdf(q).unwrap();
+            assert!((x - x_back).abs() < 1e-9 * x, "x={x}");
+        }
+        for &q in &[1e-12, 0.1, 0.5, 0.9, 1.0 - 1e-12] {
+            let x = p.inverse_cdf(q).unwrap();
+            let q_back = p.cdf(x).unwrap();
+            assert!((q - q_back).abs() < 1e-12 * q.max(1e-3), "q={q}");
+        }
+    }
+
+    #[test]
+    fn test_pareto_moments_vs_scipy() {
+        let p = Pareto::new(2.0, 3.0).unwrap();
+        // scipy: pareto(3, scale=2).mean() = 3.0, .var() = 3.0
+        assert!((p.mean() - 3.0).abs() < TOL);
+        assert!((p.variance() - 3.0).abs() < TOL);
+        // Heavy-tail regimes
+        assert_eq!(Pareto::new(2.0, 1.0).unwrap().mean(), f64::INFINITY);
+        assert_eq!(Pareto::new(2.0, 0.5).unwrap().mean(), f64::INFINITY);
+        assert_eq!(Pareto::new(2.0, 2.0).unwrap().variance(), f64::INFINITY);
+        assert_eq!(Pareto::new(2.0, 1.5).unwrap().variance(), f64::INFINITY);
+        // α = 1.5 > 1: mean finite even though variance is not
+        assert!(Pareto::new(2.0, 1.5).unwrap().mean().is_finite());
+    }
+
+    #[test]
+    fn test_pareto_fit_mle() {
+        // xₘ = min = 1.0; α̂ = n / Σ ln(xᵢ/1)
+        let data = vec![1.0, 2.0, 4.0, 8.0];
+        let p = Pareto::fit(&data).unwrap();
+        assert!((p.xm - 1.0).abs() < TOL);
+        let expected_alpha = 4.0 / (2.0_f64.ln() + 4.0_f64.ln() + 8.0_f64.ln());
+        assert!((p.alpha - expected_alpha).abs() < TOL);
+        // Invalid data
+        assert!(Pareto::fit(&[]).is_err());
+        assert!(Pareto::fit(&[1.0, -2.0, 3.0]).is_err());
+        assert!(Pareto::fit(&[1.0, 0.0, 3.0]).is_err());
+        // Constant data → Σ ln = 0 → error
+        assert!(Pareto::fit(&[3.0; 6]).is_err());
+    }
+
+    #[test]
+    fn test_pareto_log_likelihood_fast_matches_logpdf_sum() {
+        let p = Pareto::new(1.5, 2.2).unwrap();
+        let data = vec![1.6, 2.0, 3.7, 10.0, 55.0];
+        let expected: f64 = data.iter().map(|&x| p.logpdf(x).unwrap()).sum();
+        assert!((p.log_likelihood_fast(&data) - expected).abs() < 1e-10);
+        assert!((p.log_likelihood(&data).unwrap() - expected).abs() < 1e-10);
+        // Out-of-support point → −∞
+        assert_eq!(p.log_likelihood_fast(&[1.0]), f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_pareto_invalid_params() {
+        assert!(Pareto::new(f64::NAN, 1.0).is_err());
+        assert!(Pareto::new(1.0, f64::NAN).is_err());
+        assert!(Pareto::new(f64::INFINITY, 1.0).is_err());
+        assert!(Pareto::new(0.0, 1.0).is_err());
+        assert!(Pareto::new(-1.0, 1.0).is_err());
+        assert!(Pareto::new(1.0, 0.0).is_err());
+        assert!(Pareto::new(1.0, -3.0).is_err());
+    }
+}

--- a/src/distributions/poisson_distribution.rs
+++ b/src/distributions/poisson_distribution.rs
@@ -180,6 +180,17 @@ impl crate::distributions::traits::Distribution for Poisson {
     fn cdf(&self, k: u64) -> StatsResult<f64> {
         cdf(k, self.lambda)
     }
+    /// Exact tail: `S(k) = P(k+1, λ)` (lower regularized incomplete gamma),
+    /// the complement of `cdf = Q(k+1, λ)`.
+    fn sf(&self, k: u64) -> StatsResult<f64> {
+        Ok(
+            crate::utils::special_functions::regularized_incomplete_gamma(
+                k as f64 + 1.0,
+                self.lambda,
+            )
+            .clamp(0.0, 1.0),
+        )
+    }
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
         crate::distributions::traits::discrete_inverse_cdf_search(p, |k| self.cdf(k))
     }

--- a/src/distributions/poisson_distribution.rs
+++ b/src/distributions/poisson_distribution.rs
@@ -49,7 +49,7 @@
 use crate::error::{StatsError, StatsResult};
 
 /// Precomputed ln(k!) for k = 0..=20 (exact values).
-/// For k > 20, we use the Stirling approximation: ln(k!) ≈ k*ln(k) - k + 0.5*ln(2πk).
+/// For k > 20, we use ln Γ(k+1) via Lanczos (`ln_gamma`).
 /// This makes PMF O(1) per call instead of O(k).
 const LN_FACT_TABLE: [f64; 21] = [
     0.0,                     // ln(0!) = 0
@@ -76,15 +76,16 @@ const LN_FACT_TABLE: [f64; 21] = [
 ];
 
 /// Compute ln(k!) in O(1) time.
-/// Uses a precomputed table for k <= 20 and Stirling's approximation for k > 20.
+/// Uses a precomputed table for k <= 20 and `ln_gamma(k+1)` for k > 20.
 #[inline]
 fn ln_factorial(k: u64) -> f64 {
     if k <= 20 {
         LN_FACT_TABLE[k as usize]
     } else {
-        // Stirling's approximation: ln(k!) ≈ k*ln(k) - k + 0.5*ln(2πk)
-        let k_f64 = k as f64;
-        k_f64 * k_f64.ln() - k_f64 + 0.5 * (2.0 * std::f64::consts::PI * k_f64).ln()
+        // ln Γ(k+1) via Lanczos (~1e-14 relative). Bare Stirling without the
+        // 1/(12k) correction is off by ~5e-4 at k ≈ 150 — visible directly
+        // in PMF values.
+        crate::utils::special_functions::ln_gamma(k as f64 + 1.0)
     }
 }
 

--- a/src/distributions/poisson_distribution.rs
+++ b/src/distributions/poisson_distribution.rs
@@ -143,7 +143,7 @@ impl Poisson {
     /// Creates a `Poisson` distribution with validation.
     pub fn new(lambda: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !lambda.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Poisson::new: parameters must be finite".to_string(),

--- a/src/distributions/poisson_distribution.rs
+++ b/src/distributions/poisson_distribution.rs
@@ -133,6 +133,7 @@ fn cdf(k: u64, lambda: f64) -> StatsResult<f64> {
 /// assert!((p.mean() - 3.0).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Poisson {
     /// Rate parameter λ > 0
     pub lambda: f64,
@@ -141,6 +142,13 @@ pub struct Poisson {
 impl Poisson {
     /// Creates a `Poisson` distribution with validation.
     pub fn new(lambda: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !lambda.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Poisson::new: parameters must be finite".to_string(),
+            });
+        }
         if lambda <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "Poisson::new: lambda must be positive".to_string(),

--- a/src/distributions/poisson_distribution.rs
+++ b/src/distributions/poisson_distribution.rs
@@ -199,6 +199,12 @@ impl crate::distributions::traits::Distribution for Poisson {
             .clamp(0.0, 1.0),
         )
     }
+    /// Direct sampling: Knuth's product method for λ < 10, Hörmann's PTRS
+    /// transformed rejection for larger λ — no quantile search per draw.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<u64> {
+        Ok(poisson_sample(rng, self.lambda))
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<u64> {
         crate::distributions::traits::discrete_inverse_cdf_search(p, |k| self.cdf(k))
     }
@@ -207,6 +213,55 @@ impl crate::distributions::traits::Distribution for Poisson {
     }
     fn variance(&self) -> f64 {
         self.lambda
+    }
+}
+
+/// One Poisson(λ) draw without quantile search.
+///
+/// - λ < 10: Knuth's product method — multiply uniforms until the product
+///   drops below e^{−λ} (mean λ+1 uniforms, one exp per draw).
+/// - λ ≥ 10: Hörmann's PTRS transformed rejection (1993) — ~1.1 uniforms
+///   per draw with a squeeze that skips the ln/ln_gamma test most of the
+///   time. Exact for all λ.
+pub(crate) fn poisson_sample(rng: &mut dyn rand::RngCore, lambda: f64) -> u64 {
+    use crate::distributions::normal_distribution::uniform01;
+    use crate::utils::special_functions::ln_gamma;
+
+    if lambda < 10.0 {
+        let l = (-lambda).exp();
+        let mut k = 0u64;
+        let mut p = 1.0_f64;
+        loop {
+            p *= uniform01(rng);
+            if p <= l {
+                return k;
+            }
+            k += 1;
+        }
+    }
+
+    // PTRS (Hörmann): sample k = floor((2a/(0.5−|u|) + b)·u + λ + 0.43).
+    let b = 0.931 + 2.53 * lambda.sqrt();
+    let a = -0.059 + 0.02483 * b;
+    let inv_alpha = 1.1239 + 1.1328 / (b - 3.4);
+    let v_r = 0.9277 - 3.6224 / (b - 2.0);
+    loop {
+        let u = uniform01(rng) - 0.5;
+        let v = uniform01(rng);
+        let us = 0.5 - u.abs();
+        let k = ((2.0 * a / us + b) * u + lambda + 0.43).floor();
+        if us >= 0.07 && v <= v_r {
+            return k as u64;
+        }
+        if k < 0.0 || (us < 0.013 && v > us) {
+            continue;
+        }
+        // Exact acceptance test in log space.
+        if (v * inv_alpha / (a / (us * us) + b)).ln()
+            <= k * lambda.ln() - lambda - ln_gamma(k + 1.0)
+        {
+            return k as u64;
+        }
     }
 }
 

--- a/src/distributions/poisson_distribution.rs
+++ b/src/distributions/poisson_distribution.rs
@@ -111,17 +111,13 @@ fn cdf(k: u64, lambda: f64) -> StatsResult<f64> {
             message: "poisson::cdf: lambda must be positive".to_string(),
         });
     }
-    // Incremental log-factorial: O(k) total, O(1) per step.
-    let ln_lambda = lambda.ln();
-    let mut log_fact = 0.0_f64;
-    let mut cdf_sum = 0.0_f64;
-    for i in 0..=k {
-        if i > 0 {
-            log_fact += (i as f64).ln();
-        }
-        cdf_sum += ((i as f64) * ln_lambda - lambda - log_fact).exp();
-    }
-    Ok(cdf_sum.clamp(0.0, 1.0))
+    // Closed form: P(X ≤ k) = Q(k+1, λ), the upper regularized incomplete
+    // gamma. O(1) instead of the previous O(k) term-by-term sum (an exp per
+    // term), and immune to underflow of the individual terms.
+    Ok(
+        crate::utils::special_functions::regularized_incomplete_gamma_upper(k as f64 + 1.0, lambda)
+            .clamp(0.0, 1.0),
+    )
 }
 
 // ── Typed struct + DiscreteDistribution impl ───────────────────────────────────

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -9,7 +9,7 @@
 
 use crate::distributions::traits::Distribution;
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::{bisect_inverse_cdf, ln_gamma, regularized_incomplete_beta};
+use crate::utils::special_functions::{ln_gamma, regularized_incomplete_beta};
 use std::f64::consts::PI;
 
 /// Student's t-distribution with location μ, scale σ, and ν degrees of freedom.
@@ -184,12 +184,13 @@ impl Distribution for StudentT {
         let mu = self.mu;
         let sigma = self.sigma;
         let nu = self.nu;
-        Ok(bisect_inverse_cdf(
+        Ok(crate::utils::special_functions::newton_inverse_cdf(
             |x| {
                 let t = (x - mu) / sigma;
                 let ib = regularized_incomplete_beta(nu / 2.0, 0.5, nu / (t * t + nu));
                 if t >= 0.0 { 1.0 - 0.5 * ib } else { 0.5 * ib }
             },
+            |x| self.pdf(x).unwrap_or(0.0),
             p,
             lo,
             hi,

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -135,6 +135,13 @@ impl Distribution for StudentT {
         let t = (x - self.mu) / self.sigma;
         Ok(self.standard_t_cdf(t))
     }
+    /// Exact tail: `S(x) = I_{ν/(t²+ν)}(ν/2, ½)/2` for `t ≥ 0` — computed
+    /// on the incomplete-beta side that stays accurate in the tail.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        let t = (x - self.mu) / self.sigma;
+        let ib = regularized_incomplete_beta(self.nu / 2.0, 0.5, self.nu / (t * t + self.nu));
+        Ok(if t >= 0.0 { 0.5 * ib } else { 1.0 - 0.5 * ib })
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -167,6 +167,12 @@ impl Distribution for StudentT {
                 message: "StudentT::inverse_cdf: p must be in [0, 1]".to_string(),
             });
         }
+        if p == 0.0 {
+            return Ok(f64::NEG_INFINITY);
+        }
+        if p == 1.0 {
+            return Ok(f64::INFINITY);
+        }
         if p == 0.5 {
             return Ok(self.mu);
         }

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -37,7 +37,7 @@ impl StudentT {
     /// Creates a `StudentT(μ, σ, ν)` distribution.
     pub fn new(mu: f64, sigma: f64, nu: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !mu.is_finite() || !sigma.is_finite() || !nu.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "StudentT::new: parameters must be finite".to_string(),

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -23,6 +23,7 @@ use std::f64::consts::PI;
 /// assert_eq!(t.mean(), 0.0);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StudentT {
     /// Location μ
     pub mu: f64,
@@ -35,6 +36,13 @@ pub struct StudentT {
 impl StudentT {
     /// Creates a `StudentT(μ, σ, ν)` distribution.
     pub fn new(mu: f64, sigma: f64, nu: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !mu.is_finite() || !sigma.is_finite() || !nu.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "StudentT::new: parameters must be finite".to_string(),
+            });
+        }
         if sigma <= 0.0 || nu <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "StudentT::new: sigma and nu must be positive".to_string(),

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -151,6 +151,16 @@ impl Distribution for StudentT {
         Ok(if t >= 0.0 { 0.5 * ib } else { 1.0 - 0.5 * ib })
     }
 
+    /// `T = Z / √(V/ν)` with `Z` from the ziggurat and `V ~ χ²(ν)` from
+    /// Marsaglia-Tsang — exact for every ν, including ν < 2 heavy tails.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<f64> {
+        use crate::distributions::gamma_distribution::gamma_sample_unit_rate;
+        use crate::distributions::normal_distribution::ziggurat_standard_normal;
+        let z = ziggurat_standard_normal(rng);
+        let v = 2.0 * gamma_sample_unit_rate(rng, self.nu / 2.0);
+        Ok(self.mu + self.sigma * z / (v / self.nu).sqrt())
+    }
+
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {
             return Err(StatsError::InvalidInput {

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -110,6 +110,27 @@ impl Distribution for StudentT {
         Ok(log_coeff + log_tail)
     }
 
+    fn log_likelihood(&self, data: &[f64]) -> StatsResult<f64> {
+        Ok(self.log_likelihood_fast(data))
+    }
+
+    fn log_likelihood_fast(&self, data: &[f64]) -> f64 {
+        // The normalization constant (2 ln_gamma + 2 ln) only depends on the
+        // parameters — hoisted out of the loop, it stops dominating fit_all.
+        let nu = self.nu;
+        let log_coeff = ln_gamma((nu + 1.0) / 2.0)
+            - ln_gamma(nu / 2.0)
+            - 0.5 * (nu * PI).ln()
+            - self.sigma.ln();
+        let half_nu_p1 = (nu + 1.0) / 2.0;
+        let mut acc = 0.0_f64;
+        for &x in data {
+            let z = (x - self.mu) / self.sigma;
+            acc -= half_nu_p1 * (1.0 + z * z / nu).ln();
+        }
+        data.len() as f64 * log_coeff + acc
+    }
+
     fn cdf(&self, x: f64) -> StatsResult<f64> {
         let t = (x - self.mu) / self.sigma;
         Ok(self.standard_t_cdf(t))

--- a/src/distributions/student_t.rs
+++ b/src/distributions/student_t.rs
@@ -124,8 +124,15 @@ impl Distribution for StudentT {
         if p == 0.5 {
             return Ok(self.mu);
         }
-        // Bisection on the t-scale then transform back
-        let std_dev_est = self.sigma * (self.nu / (self.nu - 2.0)).sqrt().max(1.0);
+        // Bisection on the t-scale then transform back. The variance-based
+        // scale only exists for ν > 2; below that, seed with σ and let
+        // bisect_inverse_cdf expand the bracket (heavy tails reach quantiles
+        // far beyond any fixed multiple of σ).
+        let std_dev_est = if self.nu > 2.0 {
+            self.sigma * (self.nu / (self.nu - 2.0)).sqrt()
+        } else {
+            self.sigma
+        };
         let lo = self.mu - 30.0 * std_dev_est;
         let hi = self.mu + 30.0 * std_dev_est;
         let mu = self.mu;

--- a/src/distributions/traits.rs
+++ b/src/distributions/traits.rs
@@ -78,8 +78,44 @@ pub trait Distribution {
     /// Cumulative distribution function `F(x) = P(X ≤ x)`.
     fn cdf(&self, x: Self::X) -> StatsResult<f64>;
 
+    /// Survival function `S(x) = P(X > x) = 1 − F(x)`.
+    ///
+    /// The default computes `1.0 − cdf(x)`, which loses all relative
+    /// precision once `S(x) < ~1e-16` (it returns exactly 0). Distributions
+    /// with an exact tail form override this — always prefer `sf` over
+    /// `1.0 - cdf(x)` for tail probabilities and p-values.
+    fn sf(&self, x: Self::X) -> StatsResult<f64> {
+        Ok(1.0 - self.cdf(x)?)
+    }
+
     /// Quantile / inverse CDF: smallest `x` such that `F(x) ≥ p`.
     fn inverse_cdf(&self, p: f64) -> StatsResult<Self::X>;
+
+    /// Draw one random sample.
+    ///
+    /// The default uses inverse-CDF sampling: `inverse_cdf(U)` with
+    /// `U ~ Uniform(0, 1)`. Exact but potentially slow for distributions
+    /// whose quantile falls back to bisection (Gamma, Beta, F, …).
+    ///
+    /// Takes `&mut dyn RngCore` so the trait stays object-safe; any
+    /// `rand::Rng` (e.g. `rand::thread_rng()`, a seeded `ChaCha8Rng`)
+    /// coerces to it.
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> StatsResult<Self::X> {
+        // Reject u = 0.0 (probability 2⁻⁵³): several quantiles are
+        // undefined or −∞ there. u < 1.0 is already guaranteed by gen().
+        let u = loop {
+            let u: f64 = rand::Rng::r#gen(rng);
+            if u > 0.0 {
+                break u;
+            }
+        };
+        self.inverse_cdf(u)
+    }
+
+    /// Draw `n` random samples into a `Vec`.
+    fn sample_n(&self, rng: &mut dyn rand::RngCore, n: usize) -> StatsResult<Vec<Self::X>> {
+        (0..n).map(|_| self.sample(rng)).collect()
+    }
 
     /// Mean (expected value) `μ`.
     fn mean(&self) -> f64;
@@ -185,3 +221,59 @@ pub(crate) fn discrete_inverse_cdf_search(
 /// (those whose support is `u64`) and keeps existing imports working.
 pub trait DiscreteDistribution: Distribution<X = u64> {}
 impl<T: Distribution<X = u64>> DiscreteDistribution for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::distributions::normal_distribution::Normal;
+    use crate::distributions::poisson_distribution::Poisson;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn test_sample_normal_matches_distribution() {
+        let d = Normal::new(2.0, 1.5).unwrap();
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let xs = d.sample_n(&mut rng, 5000).unwrap();
+
+        let n = xs.len() as f64;
+        let mean = xs.iter().sum::<f64>() / n;
+        let var = xs.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / (n - 1.0);
+        // ~6σ bounds on the estimators for n = 5000.
+        assert!((mean - 2.0).abs() < 0.13, "mean = {mean}");
+        assert!((var - 2.25).abs() < 0.30, "var = {var}");
+
+        // KS goodness-of-fit of the sample against its own CDF.
+        let ks = crate::distributions::fitting::ks_test(&xs, |x| d.cdf(x).unwrap());
+        assert!(ks.p_value > 1e-3, "KS p = {}", ks.p_value);
+    }
+
+    #[test]
+    fn test_sample_discrete_and_determinism() {
+        let d = Poisson::new(3.0).unwrap();
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let ks = d.sample_n(&mut rng, 4000).unwrap();
+        let mean = ks.iter().sum::<u64>() as f64 / ks.len() as f64;
+        assert!((mean - 3.0).abs() < 0.12, "mean = {mean}");
+
+        // Same seed ⇒ same stream.
+        let mut rng_a = ChaCha8Rng::seed_from_u64(123);
+        let mut rng_b = ChaCha8Rng::seed_from_u64(123);
+        assert_eq!(
+            d.sample_n(&mut rng_a, 20).unwrap(),
+            d.sample_n(&mut rng_b, 20).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_sf_complements_cdf() {
+        let d = Normal::new(0.0, 1.0).unwrap();
+        for x in [-3.0, -1.0, 0.0, 1.0, 3.0] {
+            let s = d.cdf(x).unwrap() + d.sf(x).unwrap();
+            assert!((s - 1.0).abs() < 1e-12, "cdf+sf = {s} at x = {x}");
+        }
+        // Deep tail: sf keeps relative precision where 1 − cdf returns 0.
+        let tail = d.sf(10.0).unwrap();
+        assert!(tail > 0.0 && tail < 1e-20, "sf(10) = {tail}");
+    }
+}

--- a/src/distributions/traits.rs
+++ b/src/distributions/traits.rs
@@ -266,6 +266,36 @@ mod tests {
     }
 
     #[test]
+    fn test_gamma_family_samplers_ks() {
+        // Every Marsaglia-Tsang-based sampler must pass a KS test against
+        // its own CDF (n = 4000, seeded).
+        use crate::distributions::beta::Beta;
+        use crate::distributions::chi_squared::ChiSquared;
+        use crate::distributions::f_distribution::FDistribution;
+        use crate::distributions::gamma_distribution::Gamma;
+        use crate::distributions::student_t::StudentT;
+
+        fn check<D: Distribution<X = f64>>(name: &str, d: &D, seed: u64) {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let xs = d.sample_n(&mut rng, 4000).unwrap();
+            let ks = crate::distributions::fitting::ks_test(&xs, |x| d.cdf(x).unwrap_or(0.0));
+            assert!(ks.p_value > 1e-3, "{name}: KS p = {}", ks.p_value);
+        }
+
+        check("Gamma(2.5,1.5)", &Gamma::new(2.5, 1.5).unwrap(), 1);
+        check("Gamma(0.4,1) boost", &Gamma::new(0.4, 1.0).unwrap(), 2);
+        check("Beta(2,5)", &Beta::new(2.0, 5.0).unwrap(), 3);
+        check("ChiSquared(4)", &ChiSquared::new(4.0).unwrap(), 4);
+        check("StudentT(ν=5)", &StudentT::new(0.0, 1.0, 5.0).unwrap(), 5);
+        check(
+            "StudentT(ν=1.5) heavy",
+            &StudentT::new(0.0, 1.0, 1.5).unwrap(),
+            6,
+        );
+        check("F(5,10)", &FDistribution::new(5.0, 10.0).unwrap(), 7);
+    }
+
+    #[test]
     fn test_sf_complements_cdf() {
         let d = Normal::new(0.0, 1.0).unwrap();
         for x in [-3.0, -1.0, 0.0, 1.0, 3.0] {

--- a/src/distributions/traits.rs
+++ b/src/distributions/traits.rs
@@ -148,6 +148,16 @@ pub(crate) fn discrete_inverse_cdf_search(
     if p == 0.0 {
         return Ok(0);
     }
+    if p == 1.0 {
+        // For unbounded supports the quantile is +∞ (not representable in
+        // u64) — and a floating-point CDF that saturates at 1 − ε would send
+        // the doubling phase all the way to u64::MAX with O(hi) CDF calls.
+        // Bounded distributions (Binomial) special-case p = 1 before
+        // delegating here.
+        return Err(StatsError::InvalidInput {
+            message: "inverse_cdf: p = 1.0 has no finite quantile for unbounded discrete distributions; use p < 1".to_string(),
+        });
+    }
     let mut hi: u64 = 1;
     while cdf(hi)? < p {
         hi = hi.saturating_mul(2);

--- a/src/distributions/traits.rs
+++ b/src/distributions/traits.rs
@@ -296,6 +296,62 @@ mod tests {
     }
 
     #[test]
+    fn test_discrete_samplers_moments() {
+        // Every direct discrete sampler (Knuth, PTRS, BINV, quantile
+        // fallback, Gamma-Poisson mixture) must reproduce mean & variance.
+        use crate::distributions::binomial_distribution::Binomial;
+        use crate::distributions::negative_binomial::NegativeBinomial;
+        use crate::distributions::poisson_distribution::Poisson;
+
+        fn check<D: Distribution<X = u64>>(name: &str, d: &D, seed: u64) {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let n = 30_000usize;
+            let ks = d.sample_n(&mut rng, n).unwrap();
+            let nf = n as f64;
+            let mean = ks.iter().map(|&k| k as f64).sum::<f64>() / nf;
+            let var = ks
+                .iter()
+                .map(|&k| (k as f64 - mean) * (k as f64 - mean))
+                .sum::<f64>()
+                / (nf - 1.0);
+            let se_mean = d.std_dev() / nf.sqrt();
+            assert!(
+                (mean - d.mean()).abs() < 7.0 * se_mean,
+                "{name}: mean {mean} vs {}",
+                d.mean()
+            );
+            assert!(
+                (var - d.variance()).abs() / d.variance() < 0.1,
+                "{name}: var {var} vs {}",
+                d.variance()
+            );
+        }
+
+        check("Poisson(3) Knuth", &Poisson::new(3.0).unwrap(), 10);
+        check("Poisson(50) PTRS", &Poisson::new(50.0).unwrap(), 11);
+        check(
+            "Binomial(20,0.3) BINV",
+            &Binomial::new(20, 0.3).unwrap(),
+            12,
+        );
+        check(
+            "Binomial(40,0.8) flip",
+            &Binomial::new(40, 0.8).unwrap(),
+            13,
+        );
+        check(
+            "Binomial(500,0.4) fallback",
+            &Binomial::new(500, 0.4).unwrap(),
+            14,
+        );
+        check(
+            "NegBin(5,0.5) Gamma-Poisson",
+            &NegativeBinomial::new(5.0, 0.5).unwrap(),
+            15,
+        );
+    }
+
+    #[test]
     fn test_sf_complements_cdf() {
         let d = Normal::new(0.0, 1.0).unwrap();
         for x in [-3.0, -1.0, 0.0, 1.0, 3.0] {

--- a/src/distributions/uniform_distribution.rs
+++ b/src/distributions/uniform_distribution.rs
@@ -79,6 +79,7 @@ fn uniform_inverse_cdf(p: f64, a: f64, b: f64) -> StatsResult<f64> {
 /// assert!((u.mean() - 0.5).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Uniform {
     /// Lower bound a
     pub a: f64,
@@ -89,6 +90,13 @@ pub struct Uniform {
 impl Uniform {
     /// Creates a `Uniform` distribution with validation (requires a < b).
     pub fn new(a: f64, b: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !a.is_finite() || !b.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Uniform::new: parameters must be finite".to_string(),
+            });
+        }
         if a >= b {
             return Err(StatsError::InvalidInput {
                 message: "Uniform::new: a must be strictly less than b".to_string(),

--- a/src/distributions/uniform_distribution.rs
+++ b/src/distributions/uniform_distribution.rs
@@ -91,7 +91,7 @@ impl Uniform {
     /// Creates a `Uniform` distribution with validation (requires a < b).
     pub fn new(a: f64, b: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !a.is_finite() || !b.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Uniform::new: parameters must be finite".to_string(),

--- a/src/distributions/weibull.rs
+++ b/src/distributions/weibull.rs
@@ -67,7 +67,7 @@ impl Weibull {
     /// Creates a `Weibull(k, λ)` distribution.
     pub fn new(k: f64, lambda: f64) -> StatsResult<Self> {
         // Non-finite parameters (NaN, ±inf) silently produced NaN
-        // pdf/cdf values before v3.1 — reject them up front.
+        // pdf/cdf values before v4.0 — reject them up front.
         if !k.is_finite() || !lambda.is_finite() {
             return Err(StatsError::InvalidInput {
                 message: "Weibull::new: parameters must be finite".to_string(),

--- a/src/distributions/weibull.rs
+++ b/src/distributions/weibull.rs
@@ -157,7 +157,8 @@ impl Distribution for Weibull {
         if x <= 0.0 {
             return Ok(0.0);
         }
-        Ok(1.0 - (-(x / self.lambda).powf(self.k)).exp())
+        // −expm1(−t) keeps relative precision when (x/λ)^k ≪ 1.
+        Ok(-(-(x / self.lambda).powf(self.k)).exp_m1())
     }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
@@ -173,7 +174,8 @@ impl Distribution for Weibull {
             return Ok(f64::INFINITY);
         }
         // Closed-form inverse: x = λ · (-ln(1-p))^(1/k)
-        Ok(self.lambda * (-(1.0 - p).ln()).powf(1.0 / self.k))
+        // −ln_1p(−p) keeps p's low bits for small p (1.0 − p would drop them).
+        Ok(self.lambda * (-(-p).ln_1p()).powf(1.0 / self.k))
     }
 
     fn mean(&self) -> f64 {

--- a/src/distributions/weibull.rs
+++ b/src/distributions/weibull.rs
@@ -55,6 +55,7 @@ use crate::utils::special_functions::gamma_fn;
 /// assert!((w.mean() - 2.0).abs() < 1e-10);
 /// ```
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Weibull {
     /// Shape parameter k > 0
     pub k: f64,
@@ -65,6 +66,13 @@ pub struct Weibull {
 impl Weibull {
     /// Creates a `Weibull(k, λ)` distribution.
     pub fn new(k: f64, lambda: f64) -> StatsResult<Self> {
+        // Non-finite parameters (NaN, ±inf) silently produced NaN
+        // pdf/cdf values before v3.1 — reject them up front.
+        if !k.is_finite() || !lambda.is_finite() {
+            return Err(StatsError::InvalidInput {
+                message: "Weibull::new: parameters must be finite".to_string(),
+            });
+        }
         if k <= 0.0 || lambda <= 0.0 {
             return Err(StatsError::InvalidInput {
                 message: "Weibull::new: k and lambda must be positive".to_string(),

--- a/src/distributions/weibull.rs
+++ b/src/distributions/weibull.rs
@@ -160,6 +160,13 @@ impl Distribution for Weibull {
         // −expm1(−t) keeps relative precision when (x/λ)^k ≪ 1.
         Ok(-(-(x / self.lambda).powf(self.k)).exp_m1())
     }
+    /// Exact tail: `S(x) = exp(−(x/λ)^k)`.
+    fn sf(&self, x: f64) -> StatsResult<f64> {
+        if x <= 0.0 {
+            return Ok(1.0);
+        }
+        Ok((-(x / self.lambda).powf(self.k)).exp())
+    }
 
     fn inverse_cdf(&self, p: f64) -> StatsResult<f64> {
         if !(0.0..=1.0).contains(&p) {

--- a/src/hypothesis_tests/anova.rs
+++ b/src/hypothesis_tests/anova.rs
@@ -164,6 +164,11 @@ where
     // Calculate mean squares
     let ms_between = ss_between / (df_between as f64);
     let ms_within = ss_within / (df_within as f64);
+    if ms_within == 0.0 {
+        return Err(StatsError::invalid_input(
+            "one_way_anova: zero within-group variance; the F-statistic is undefined",
+        ));
+    }
 
     // Calculate F-statistic
     let f_statistic = ms_between / ms_within;
@@ -510,47 +515,25 @@ mod tests {
     }
 
     #[test]
-    fn test_f_distribution_cdf_f_zero() {
-        // Test f_distribution_cdf with f = 0.0 (should return 0.0)
-        // This can happen when all groups have identical means
-        // Note: When all groups are identical, ms_within might be 0, causing F to be NaN
-        // This is a valid edge case - we test that the function handles it
+    fn test_anova_zero_within_variance_is_error() {
+        // All groups constant → ms_within = 0 → F undefined. This used to
+        // silently produce a NaN F-statistic; it is now a typed error.
         let group1 = [5.0, 5.0, 5.0];
         let group2 = [5.0, 5.0, 5.0];
         let group3 = [5.0, 5.0, 5.0];
 
         let groups = [&group1[..], &group2[..], &group3[..]];
-        let result = one_way_anova(&groups).unwrap();
+        let result = one_way_anova(&groups);
+        assert!(matches!(
+            result.unwrap_err(),
+            StatsError::InvalidInput { .. }
+        ));
 
-        // When all groups have identical values, ms_within = 0, so F = ms_between / 0 = NaN
-        // This is expected behavior - we just verify the result doesn't panic
-        // F-statistic can be NaN in this edge case
-        assert!(
-            result.f_statistic.is_nan() || result.f_statistic >= 0.0,
-            "F-statistic should be NaN or non-negative"
-        );
-    }
-
-    #[test]
-    fn test_f_distribution_cdf_f_negative() {
-        // Test that f_distribution_cdf handles f <= 0.0 correctly
-        // This should return 0.0
-        // We can't directly test this through ANOVA since F-statistic is always >= 0
-        // But we can verify that the function handles edge cases correctly
-        // by testing with groups that have very small differences
-        // Note: When groups are identical, F may be NaN (0/0)
+        // Two identical constant groups: same 0/0 case, same error.
         let group1 = [1.0, 1.0, 1.0];
         let group2 = [1.0, 1.0, 1.0];
-
         let groups = [&group1[..], &group2[..]];
-        let result = one_way_anova(&groups).unwrap();
-
-        // F-statistic can be NaN when groups are identical (0/0 case)
-        // This is expected - we just verify it doesn't panic
-        assert!(
-            result.f_statistic.is_nan() || result.f_statistic >= 0.0,
-            "F-statistic should be NaN or non-negative"
-        );
+        assert!(one_way_anova(&groups).is_err());
     }
 
     #[test]

--- a/src/hypothesis_tests/anova.rs
+++ b/src/hypothesis_tests/anova.rs
@@ -53,6 +53,16 @@ pub struct AnovaResult {
     pub ms_within: f64,
 }
 
+impl AnovaResult {
+    /// Eta-squared effect size: `η² = SS_between / (SS_between + SS_within)`
+    /// — the proportion of total variance explained by group membership.
+    ///
+    /// Rule-of-thumb magnitudes: 0.01 small, 0.06 medium, 0.14 large.
+    pub fn eta_squared(&self) -> f64 {
+        self.ss_between / (self.ss_between + self.ss_within)
+    }
+}
+
 /// Performs a one-way Analysis of Variance (ANOVA) test on multiple groups of data
 ///
 /// Tests the null hypothesis that all group means are equal against the alternative

--- a/src/hypothesis_tests/anova.rs
+++ b/src/hypothesis_tests/anova.rs
@@ -27,6 +27,7 @@
 use crate::error::{StatsError, StatsResult};
 use crate::utils::special_functions::regularized_incomplete_beta as canonical_inc_beta;
 use num_traits::ToPrimitive;
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::fmt::Debug;
 
@@ -110,8 +111,11 @@ where
     // worker and emits its `(count, mean, m2)` triple. ss_within = Σ m2
     // falls out without a second pass over the data.
     let n_groups = groups_data.len();
-    let triples: Vec<Result<(f64, f64, f64), StatsError>> = groups_data
-        .par_iter()
+    #[cfg(feature = "parallel")]
+    let groups_iter = groups_data.par_iter();
+    #[cfg(not(feature = "parallel"))]
+    let groups_iter = groups_data.iter();
+    let triples: Vec<Result<(f64, f64, f64), StatsError>> = groups_iter
         .enumerate()
         .map(|(group_idx, group)| {
             let mut count = 0.0_f64;

--- a/src/hypothesis_tests/chi_square_test.rs
+++ b/src/hypothesis_tests/chi_square_test.rs
@@ -44,7 +44,7 @@ fn chi_square_sf(chi_sq: f64, df: usize) -> f64 {
 
 /// Result of a chi-square test.
 ///
-/// Replaces the pre-v3.1 positional `(statistic, df, p_value)` tuple —
+/// Replaces the pre-v4.0 positional `(statistic, df, p_value)` tuple —
 /// named fields, consistent with [`TTestResult`](crate::hypothesis_tests::t_test::TTestResult)
 /// and [`AnovaResult`](crate::hypothesis_tests::anova::AnovaResult).
 #[derive(Debug, Clone, Copy)]

--- a/src/hypothesis_tests/chi_square_test.rs
+++ b/src/hypothesis_tests/chi_square_test.rs
@@ -18,7 +18,6 @@
 //! The resulting statistic follows a chi-square distribution with degrees of freedom based on the particular test.
 
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::regularized_incomplete_gamma;
 use num_traits::ToPrimitive;
 use std::fmt::Debug;
 
@@ -34,7 +33,29 @@ fn chi_square_sf(chi_sq: f64, df: usize) -> f64 {
     if chi_sq <= 0.0 {
         return 1.0;
     }
-    (1.0 - regularized_incomplete_gamma(df as f64 / 2.0, chi_sq / 2.0)).clamp(0.0, 1.0)
+    // Upper incomplete gamma directly: keeps relative precision for tiny
+    // tail p-values where 1 − P collapses to 0.
+    crate::utils::special_functions::regularized_incomplete_gamma_upper(
+        df as f64 / 2.0,
+        chi_sq / 2.0,
+    )
+    .clamp(0.0, 1.0)
+}
+
+/// Result of a chi-square test.
+///
+/// Replaces the pre-v3.1 positional `(statistic, df, p_value)` tuple —
+/// named fields, consistent with [`TTestResult`](crate::hypothesis_tests::t_test::TTestResult)
+/// and [`AnovaResult`](crate::hypothesis_tests::anova::AnovaResult).
+#[derive(Debug, Clone, Copy)]
+pub struct ChiSquareResult {
+    /// The χ² statistic.
+    pub statistic: f64,
+    /// Degrees of freedom.
+    pub degrees_of_freedom: usize,
+    /// p-value: `P(χ²_df ≥ statistic)` under H₀ — compare it to your
+    /// significance level α (reject H₀ when `p_value < α`).
+    pub p_value: f64,
 }
 
 /// Performs a chi-square goodness of fit test, which determines if a sample matches a population distribution.
@@ -47,10 +68,9 @@ fn chi_square_sf(chi_sq: f64, df: usize) -> f64 {
 /// * `expected` - A slice containing the expected frequencies for each category
 ///
 /// # Returns
-/// `StatsResult<(f64, usize, f64)>` containing:
-/// * The chi-square statistic
-/// * The degrees of freedom
-/// * The p-value (if the statistic is less than this value, the null hypothesis cannot be rejected)
+/// A [`ChiSquareResult`] with the χ² statistic, the degrees of freedom and
+/// the p-value (`P(χ²_df ≥ statistic)` under H₀; reject H₀ when
+/// `p_value < α`).
 ///
 /// # Errors
 /// * Returns `StatsError::EmptyData` if the slices are empty
@@ -66,16 +86,16 @@ fn chi_square_sf(chi_sq: f64, df: usize) -> f64 {
 /// let observed = vec![89, 105, 97, 99, 110, 100]; // Outcomes of 600 die rolls
 /// let expected = vec![100.0, 100.0, 100.0, 100.0, 100.0, 100.0]; // Expected frequencies for a fair die
 ///
-/// let (statistic, df, p_value) = chi_square_goodness_of_fit(&observed, &expected)?;
-/// println!("Chi-square statistic: {}", statistic);
-/// println!("Degrees of freedom: {}", df);
-/// println!("P-value: {}", p_value);
+/// let res = chi_square_goodness_of_fit(&observed, &expected)?;
+/// println!("Chi-square statistic: {}", res.statistic);
+/// println!("Degrees of freedom: {}", res.degrees_of_freedom);
+/// println!("P-value: {}", res.p_value);
 /// # Ok::<(), rs_stats::StatsError>(())
 /// ```
 pub fn chi_square_goodness_of_fit<T, U>(
     observed: &[T],
     expected: &[U],
-) -> StatsResult<(f64, usize, f64)>
+) -> StatsResult<ChiSquareResult>
 where
     T: ToPrimitive + Debug + Copy,
     U: ToPrimitive + Debug + Copy,
@@ -128,7 +148,11 @@ where
 
     let p_value = chi_square_sf(chi_square, degrees_of_freedom);
 
-    Ok((chi_square, degrees_of_freedom, p_value))
+    Ok(ChiSquareResult {
+        statistic: chi_square,
+        degrees_of_freedom,
+        p_value,
+    })
 }
 
 /// Performs a chi-square test of independence, which determines if there is a significant relationship
@@ -140,10 +164,9 @@ where
 /// * `observed_matrix` - A 2D vector representing the contingency table of observed frequencies
 ///
 /// # Returns
-/// `StatsResult<(f64, usize, f64)>` containing:
-/// * The chi-square statistic
-/// * The degrees of freedom
-/// * The p-value (if the statistic is less than this value, the null hypothesis cannot be rejected)
+/// A [`ChiSquareResult`] with the χ² statistic, the degrees of freedom and
+/// the p-value (`P(χ²_df ≥ statistic)` under H₀; reject H₀ when
+/// `p_value < α`).
 ///
 /// # Errors
 /// * Returns `StatsError::EmptyData` if the matrix is empty
@@ -161,13 +184,13 @@ where
 ///     vec![40, 180],  // Smokers: [No cancer, Cancer]
 /// ];
 ///
-/// let (statistic, df, p_value) = chi_square_independence(&observed)?;
-/// println!("Chi-square statistic: {}", statistic);
-/// println!("Degrees of freedom: {}", df);
-/// println!("P-value: {}", p_value);
+/// let res = chi_square_independence(&observed)?;
+/// println!("Chi-square statistic: {}", res.statistic);
+/// println!("Degrees of freedom: {}", res.degrees_of_freedom);
+/// println!("P-value: {}", res.p_value);
 /// # Ok::<(), rs_stats::StatsError>(())
 /// ```
-pub fn chi_square_independence<T>(observed_matrix: &[Vec<T>]) -> StatsResult<(f64, usize, f64)>
+pub fn chi_square_independence<T>(observed_matrix: &[Vec<T>]) -> StatsResult<ChiSquareResult>
 where
     T: ToPrimitive + Debug + Copy,
 {
@@ -270,7 +293,11 @@ where
 
     let p_value = chi_square_sf(chi_square, degrees_of_freedom);
 
-    Ok((chi_square, degrees_of_freedom, p_value))
+    Ok(ChiSquareResult {
+        statistic: chi_square,
+        degrees_of_freedom,
+        p_value,
+    })
 }
 
 #[cfg(test)]
@@ -283,7 +310,8 @@ mod tests {
         let observed = vec![24, 20, 18, 22, 15, 21]; // 120 rolls
         let expected = vec![20.0, 20.0, 20.0, 20.0, 20.0, 20.0]; // Equal probability for each face
 
-        let (statistic, df, _) = chi_square_goodness_of_fit(&observed, &expected).unwrap();
+        let r = chi_square_goodness_of_fit(&observed, &expected).unwrap();
+        let (statistic, df) = (r.statistic, r.degrees_of_freedom);
 
         // Verify that degrees of freedom is correct
         assert_eq!(df, 5, "Degrees of freedom should be 5");
@@ -305,7 +333,8 @@ mod tests {
         let observed = vec![10, 15, 25];
         let expected = vec![16.6667, 16.6667, 16.6667]; // Equal probability over 3 categories for 50 trials
 
-        let (statistic, df, _) = chi_square_goodness_of_fit(&observed, &expected).unwrap();
+        let r = chi_square_goodness_of_fit(&observed, &expected).unwrap();
+        let (statistic, df) = (r.statistic, r.degrees_of_freedom);
 
         assert_eq!(df, 2, "Degrees of freedom should be 2");
 
@@ -331,7 +360,8 @@ mod tests {
         // Female     |    60    |    40    |
         let observed = vec![vec![45, 55], vec![60, 40]];
 
-        let (statistic, df, _) = chi_square_independence(&observed).unwrap();
+        let r = chi_square_independence(&observed).unwrap();
+        let (statistic, df) = (r.statistic, r.degrees_of_freedom);
 
         assert_eq!(df, 1, "Degrees of freedom should be 1");
 
@@ -361,7 +391,8 @@ mod tests {
         // Testing a 3x3 contingency table
         let observed = vec![vec![30, 25, 15], vec![35, 40, 30], vec![20, 30, 25]];
 
-        let (statistic, df, _) = chi_square_independence(&observed).unwrap();
+        let r = chi_square_independence(&observed).unwrap();
+        let (statistic, df) = (r.statistic, r.degrees_of_freedom);
 
         assert_eq!(df, 4, "Degrees of freedom should be 4");
 
@@ -433,7 +464,8 @@ mod tests {
         let observed = vec![10];
         let expected = vec![10.0];
 
-        let (statistic, df, p_value) = chi_square_goodness_of_fit(&observed, &expected).unwrap();
+        let r = chi_square_goodness_of_fit(&observed, &expected).unwrap();
+        let (statistic, df, p_value) = (r.statistic, r.degrees_of_freedom, r.p_value);
 
         assert_eq!(df, 0, "Degrees of freedom should be 0 for single category");
         assert_eq!(

--- a/src/hypothesis_tests/chi_square_test.rs
+++ b/src/hypothesis_tests/chi_square_test.rs
@@ -219,6 +219,14 @@ where
         }
     }
 
+    if total_sum <= 0.0 {
+        // An all-zero table would make every expected count 0/0 = NaN, and
+        // the per-cell `expected <= 0.0` guard below never fires on NaN.
+        return Err(StatsError::invalid_input(
+            "chi_square_independence: the contingency table sums to zero",
+        ));
+    }
+
     // Calculate expected values and chi-square statistic
     let mut chi_square = 0.0;
 

--- a/src/hypothesis_tests/fisher.rs
+++ b/src/hypothesis_tests/fisher.rs
@@ -47,10 +47,12 @@ pub fn fisher_exact(
     d: u64,
     alternative: Alternative,
 ) -> StatsResult<FisherExactResult> {
-    let row1 = a + b;
-    let row2 = c + d;
-    let col1 = a + c;
-    let n = row1 + row2;
+    let overflow =
+        || StatsError::invalid_input("fisher_exact: counts too large (sum overflows u64)");
+    let row1 = a.checked_add(b).ok_or_else(overflow)?;
+    let row2 = c.checked_add(d).ok_or_else(overflow)?;
+    let col1 = a.checked_add(c).ok_or_else(overflow)?;
+    let n = row1.checked_add(row2).ok_or_else(overflow)?;
     if n == 0 {
         return Err(StatsError::invalid_input(
             "fisher_exact: the table must contain at least one observation",

--- a/src/hypothesis_tests/fisher.rs
+++ b/src/hypothesis_tests/fisher.rs
@@ -1,0 +1,141 @@
+//! # Fisher's exact test (2×2 contingency tables)
+//!
+//! Exact test of independence for a 2×2 table — the tool of choice when
+//! expected cell counts are too small for the chi-square approximation
+//! (the usual rule of thumb: any expected count < 5). Matches
+//! `scipy.stats.fisher_exact` conventions.
+
+use crate::error::{StatsError, StatsResult};
+use crate::hypothesis_tests::Alternative;
+use crate::utils::special_functions::ln_gamma;
+
+/// Result of Fisher's exact test.
+#[derive(Debug, Clone, Copy)]
+pub struct FisherExactResult {
+    /// Sample odds ratio `(a·d)/(b·c)` (`inf` when `b·c = 0`).
+    pub odds_ratio: f64,
+    /// Exact p-value under the chosen [`Alternative`].
+    pub p_value: f64,
+}
+
+/// ln C(n, k) for the hypergeometric weights.
+fn ln_choose(n: u64, k: u64) -> f64 {
+    ln_gamma(n as f64 + 1.0) - ln_gamma(k as f64 + 1.0) - ln_gamma((n - k) as f64 + 1.0)
+}
+
+/// Fisher's exact test on the 2×2 table `[[a, b], [c, d]]`.
+///
+/// Conditions on the margins: under H₀ the count `a` follows a
+/// hypergeometric distribution. `Alternative::TwoSided` sums the
+/// probabilities of all tables at most as likely as the observed one
+/// (scipy's definition); `Greater` tests for a *positive* association
+/// (large `a`), `Less` for a negative one.
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::{Alternative, fisher_exact};
+///
+/// // Treatment: 8/10 responders — control: 1/6.
+/// let res = fisher_exact(8, 2, 1, 5, Alternative::TwoSided).unwrap();
+/// assert!(res.p_value < 0.05);
+/// assert!((res.odds_ratio - 20.0).abs() < 1e-12);
+/// ```
+pub fn fisher_exact(
+    a: u64,
+    b: u64,
+    c: u64,
+    d: u64,
+    alternative: Alternative,
+) -> StatsResult<FisherExactResult> {
+    let row1 = a + b;
+    let row2 = c + d;
+    let col1 = a + c;
+    let n = row1 + row2;
+    if n == 0 {
+        return Err(StatsError::invalid_input(
+            "fisher_exact: the table must contain at least one observation",
+        ));
+    }
+
+    let odds_ratio = if b * c == 0 {
+        if a * d == 0 { f64::NAN } else { f64::INFINITY }
+    } else {
+        (a as f64 * d as f64) / (b as f64 * c as f64)
+    };
+
+    // Support of a: max(0, col1 − row2) ..= min(row1, col1).
+    let k_min = col1.saturating_sub(row2);
+    let k_max = row1.min(col1);
+
+    // Hypergeometric log-PMF of each possible a, normalised by ln C(n, col1).
+    let ln_norm = ln_choose(n, col1);
+    let ln_pmf = |k: u64| ln_choose(row1, k) + ln_choose(row2, col1 - k) - ln_norm;
+
+    let ln_p_obs = ln_pmf(a);
+    let mut p_two = 0.0_f64;
+    let mut p_less = 0.0_f64;
+    let mut p_greater = 0.0_f64;
+    // Relative slack for "at most as likely" comparisons (scipy uses the
+    // same guard against floating-point noise on equal-probability tables).
+    const REL_EPS: f64 = 1e-7;
+    for k in k_min..=k_max {
+        let lp = ln_pmf(k);
+        let p = lp.exp();
+        if lp <= ln_p_obs + REL_EPS {
+            p_two += p;
+        }
+        if k <= a {
+            p_less += p;
+        }
+        if k >= a {
+            p_greater += p;
+        }
+    }
+
+    let p_value = match alternative {
+        Alternative::TwoSided => p_two,
+        Alternative::Less => p_less,
+        Alternative::Greater => p_greater,
+    }
+    .clamp(0.0, 1.0);
+
+    Ok(FisherExactResult {
+        odds_ratio,
+        p_value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fisher_matches_scipy() {
+        // Reference: scipy.stats.fisher_exact([[8, 2], [1, 5]]).
+        let two = fisher_exact(8, 2, 1, 5, Alternative::TwoSided).unwrap();
+        assert!((two.odds_ratio - 20.0).abs() < 1e-12);
+        assert!((two.p_value - 0.034965034965034975).abs() < 1e-12);
+
+        let less = fisher_exact(8, 2, 1, 5, Alternative::Less).unwrap();
+        assert!((less.p_value - 0.9991258741258742).abs() < 1e-12);
+
+        let greater = fisher_exact(8, 2, 1, 5, Alternative::Greater).unwrap();
+        assert!((greater.p_value - 0.024475524475524483).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_fisher_no_association() {
+        // Perfectly balanced table → p = 1.
+        let res = fisher_exact(5, 5, 5, 5, Alternative::TwoSided).unwrap();
+        assert!((res.p_value - 1.0).abs() < 1e-10);
+        assert!((res.odds_ratio - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_fisher_zero_cell() {
+        let res = fisher_exact(10, 0, 0, 10, Alternative::TwoSided).unwrap();
+        assert!(res.odds_ratio.is_infinite());
+        assert!(res.p_value < 1e-4);
+        assert!(fisher_exact(0, 0, 0, 0, Alternative::TwoSided).is_err());
+    }
+}

--- a/src/hypothesis_tests/ks.rs
+++ b/src/hypothesis_tests/ks.rs
@@ -1,0 +1,123 @@
+//! # Two-sample Kolmogorov-Smirnov test
+//!
+//! Non-parametric test of whether two independent samples come from the
+//! same continuous distribution, based on the maximum distance between
+//! their empirical CDFs. Matches `scipy.stats.ks_2samp(method="asymp")`.
+//!
+//! For goodness-of-fit of one sample against a *known* distribution, use
+//! [`crate::distributions::fitting::ks_test`].
+
+use crate::distributions::fitting::{KsResult, kolmogorov_p};
+use crate::error::{StatsError, StatsResult};
+use num_traits::ToPrimitive;
+
+/// Two-sample Kolmogorov-Smirnov test.
+///
+/// Returns the KS statistic `D = sup |F₁(x) − F₂(x)|` and the two-sided
+/// p-value from the Kolmogorov distribution with the Numerical-Recipes
+/// finite-sample correction (`(√nₑ + 0.12 + 0.11/√nₑ)·D`,
+/// `nₑ = n₁n₂/(n₁+n₂)`) — the same convention as this crate's one-sample
+/// [`ks_test`](crate::distributions::fitting::ks_test). The statistic
+/// matches scipy exactly; the p-value can differ from
+/// `scipy.stats.ks_2samp` by O(1/√n) (scipy applies its own finite-n
+/// correction). Reasonable for `n₁, n₂ ≳ 10`.
+///
+/// # Errors
+/// Returns an error if either sample is empty or contains values not
+/// convertible to `f64`.
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::ks_2samp;
+///
+/// let a = [1.2, 2.4, 3.1, 4.8, 5.5, 6.1, 7.9, 8.2];
+/// let b = [1.4, 2.1, 3.5, 4.2, 5.9, 6.6, 7.1, 8.8];
+/// let res = ks_2samp(&a, &b).unwrap();
+/// assert!(res.p_value > 0.5); // same underlying distribution
+/// ```
+pub fn ks_2samp<X, Y>(a: &[X], b: &[Y]) -> StatsResult<KsResult>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    if a.is_empty() || b.is_empty() {
+        return Err(StatsError::invalid_input(
+            "ks_2samp: both samples must be non-empty",
+        ));
+    }
+    let mut xa: Vec<f64> = a
+        .iter()
+        .map(|v| v.to_f64())
+        .collect::<Option<_>>()
+        .ok_or_else(|| StatsError::conversion_error("ks_2samp: a not convertible to f64"))?;
+    let mut xb: Vec<f64> = b
+        .iter()
+        .map(|v| v.to_f64())
+        .collect::<Option<_>>()
+        .ok_or_else(|| StatsError::conversion_error("ks_2samp: b not convertible to f64"))?;
+    xa.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    xb.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+
+    let (n1, n2) = (xa.len(), xb.len());
+    let (n1f, n2f) = (n1 as f64, n2 as f64);
+
+    // Two-pointer sweep over the merged order; at each distinct value,
+    // advance BOTH pointers past their ties before comparing the ECDFs
+    // (a tie shared by the two samples is not a crossing point).
+    let (mut i, mut j) = (0usize, 0usize);
+    let mut d = 0.0_f64;
+    while i < n1 && j < n2 {
+        let x = xa[i].min(xb[j]);
+        while i < n1 && xa[i] == x {
+            i += 1;
+        }
+        while j < n2 && xb[j] == x {
+            j += 1;
+        }
+        let diff = (i as f64 / n1f - j as f64 / n2f).abs();
+        d = d.max(diff);
+    }
+    // Once one sample is exhausted the ECDF gap only shrinks back to 0 —
+    // no further candidates.
+
+    let sqrt_en = (n1f * n2f / (n1f + n2f)).sqrt();
+    Ok(KsResult {
+        statistic: d,
+        p_value: kolmogorov_p((sqrt_en + 0.12 + 0.11 / sqrt_en) * d),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ks_2samp_matches_references() {
+        let a = [
+            1.5, 2.1, 3.3, 4.0, 5.2, 6.1, 7.4, 8.0, 9.3, 10.0, 11.2, 12.5,
+        ];
+        let b = [2.0, 3.5, 4.1, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1, 12.0, 13.5];
+        let res = ks_2samp(&a, &b).unwrap();
+        // Statistic matches scipy exactly.
+        assert!((res.statistic - 0.1590909090909091).abs() < 1e-12);
+        // p-value: NR-corrected Kolmogorov asymptotic
+        // (kstwobign.sf((√nₑ+0.12+0.11/√nₑ)·D) = 0.99635…); scipy's own
+        // finite-n correction gives 0.99129 — same conclusion either way.
+        assert!((res.p_value - 0.9963463314278793).abs() < 1e-9);
+        assert!((res.p_value - 0.9912889825608985).abs() < 0.02);
+    }
+
+    #[test]
+    fn test_ks_2samp_shifted_distributions() {
+        let a: Vec<f64> = (0..50).map(|i| i as f64 * 0.1).collect();
+        let b: Vec<f64> = (0..50).map(|i| i as f64 * 0.1 + 3.0).collect();
+        let res = ks_2samp(&a, &b).unwrap();
+        assert!(res.statistic > 0.5);
+        assert!(res.p_value < 1e-6);
+    }
+
+    #[test]
+    fn test_ks_2samp_empty() {
+        assert!(ks_2samp::<f64, f64>(&[], &[1.0]).is_err());
+    }
+}

--- a/src/hypothesis_tests/mann_whitney.rs
+++ b/src/hypothesis_tests/mann_whitney.rs
@@ -77,6 +77,11 @@ where
         })?);
     }
 
+    if pooled.iter().any(|v| v.is_nan()) {
+        return Err(StatsError::invalid_input(
+            "mann_whitney_u: samples contain NaN",
+        ));
+    }
     let ranks = average_ranks(&pooled);
     let r1: f64 = ranks[..n1].iter().sum();
     let u1 = r1 - (n1 * (n1 + 1)) as f64 / 2.0;

--- a/src/hypothesis_tests/mann_whitney.rs
+++ b/src/hypothesis_tests/mann_whitney.rs
@@ -98,8 +98,7 @@ where
         i = j;
     }
     let nf = n as f64;
-    let sigma_sq =
-        (n1 * n2) as f64 / 12.0 * ((nf + 1.0) - tie_term / (nf * (nf - 1.0)));
+    let sigma_sq = (n1 * n2) as f64 / 12.0 * ((nf + 1.0) - tie_term / (nf * (nf - 1.0)));
     if sigma_sq <= 0.0 {
         return Err(StatsError::invalid_input(
             "mann_whitney_u: all pooled values are identical; the test is undefined",

--- a/src/hypothesis_tests/mann_whitney.rs
+++ b/src/hypothesis_tests/mann_whitney.rs
@@ -1,0 +1,173 @@
+//! # Mann-Whitney U test (Wilcoxon rank-sum)
+//!
+//! Non-parametric test of whether two independent samples come from the
+//! same distribution. Uses the normal approximation with tie correction
+//! and continuity correction — matching
+//! `scipy.stats.mannwhitneyu(method="asymptotic")` (its default
+//! `use_continuity=True`). Appropriate for `n ≳ 8` per group; below that,
+//! prefer an exact-table lookup (not implemented here).
+
+use crate::error::{StatsError, StatsResult};
+use crate::hypothesis_tests::Alternative;
+use crate::prob::erfc;
+use crate::utils::numeric::average_ranks;
+use num_traits::ToPrimitive;
+
+/// Result of a Mann-Whitney U test.
+#[derive(Debug, Clone, Copy)]
+pub struct MannWhitneyResult {
+    /// U statistic of the **first** sample (`U₁`), as in scipy.
+    pub u_statistic: f64,
+    /// Standard-normal z used for the p-value (continuity-corrected).
+    pub z_score: f64,
+    /// p-value under the chosen [`Alternative`].
+    pub p_value: f64,
+}
+
+/// Standard normal survival function via erfc (exact in the tails).
+fn norm_sf(z: f64) -> f64 {
+    0.5 * erfc(z / std::f64::consts::SQRT_2).unwrap_or(f64::NAN)
+}
+
+/// Mann-Whitney U test on two independent samples.
+///
+/// `Alternative::Less` means "`a` is stochastically smaller than `b`"
+/// (scipy convention).
+///
+/// # Errors
+/// Returns an error if either sample is empty or if all pooled values are
+/// identical (the rank variance is then zero and the test is undefined).
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::{Alternative, mann_whitney_u};
+///
+/// let a = [1.5, 2.1, 3.3, 4.0];
+/// let b = [3.9, 5.5, 6.6, 7.7];
+/// let res = mann_whitney_u(&a, &b, Alternative::TwoSided).unwrap();
+/// assert!(res.p_value < 0.15);
+/// ```
+pub fn mann_whitney_u<X, Y>(
+    a: &[X],
+    b: &[Y],
+    alternative: Alternative,
+) -> StatsResult<MannWhitneyResult>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    if a.is_empty() || b.is_empty() {
+        return Err(StatsError::invalid_input(
+            "mann_whitney_u: both samples must be non-empty",
+        ));
+    }
+    let n1 = a.len();
+    let n2 = b.len();
+    let n = n1 + n2;
+
+    let mut pooled: Vec<f64> = Vec::with_capacity(n);
+    for v in a {
+        pooled.push(v.to_f64().ok_or_else(|| {
+            StatsError::conversion_error("mann_whitney_u: a not convertible to f64")
+        })?);
+    }
+    for v in b {
+        pooled.push(v.to_f64().ok_or_else(|| {
+            StatsError::conversion_error("mann_whitney_u: b not convertible to f64")
+        })?);
+    }
+
+    let ranks = average_ranks(&pooled);
+    let r1: f64 = ranks[..n1].iter().sum();
+    let u1 = r1 - (n1 * (n1 + 1)) as f64 / 2.0;
+    let u2 = (n1 * n2) as f64 - u1;
+
+    // Tie-corrected variance of U:
+    // σ² = n1·n2/12 · [(N+1) − Σ(t³−t)/(N(N−1))]
+    let mut sorted = pooled;
+    sorted.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    let mut tie_term = 0.0_f64;
+    let mut i = 0;
+    while i < n {
+        let mut j = i + 1;
+        while j < n && sorted[j] == sorted[i] {
+            j += 1;
+        }
+        let t = (j - i) as f64;
+        tie_term += t * t * t - t;
+        i = j;
+    }
+    let nf = n as f64;
+    let sigma_sq =
+        (n1 * n2) as f64 / 12.0 * ((nf + 1.0) - tie_term / (nf * (nf - 1.0)));
+    if sigma_sq <= 0.0 {
+        return Err(StatsError::invalid_input(
+            "mann_whitney_u: all pooled values are identical; the test is undefined",
+        ));
+    }
+    let sigma = sigma_sq.sqrt();
+    let mu = (n1 * n2) as f64 / 2.0;
+
+    // Continuity correction of 0.5, applied toward the mean (scipy).
+    let (z, p_value) = match alternative {
+        Alternative::TwoSided => {
+            let z = (u1.max(u2) - mu - 0.5) / sigma;
+            (z, (2.0 * norm_sf(z)).min(1.0))
+        }
+        Alternative::Greater => {
+            let z = (u1 - mu - 0.5) / sigma;
+            (z, norm_sf(z))
+        }
+        Alternative::Less => {
+            let z = (u2 - mu - 0.5) / sigma;
+            (z, norm_sf(z))
+        }
+    };
+
+    Ok(MannWhitneyResult {
+        u_statistic: u1,
+        z_score: z,
+        p_value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.mannwhitneyu(method='asymptotic').
+    const A: [f64; 8] = [1.5, 2.1, 3.3, 4.0, 5.2, 6.1, 7.4, 8.0];
+    const B: [f64; 9] = [2.0, 3.5, 4.1, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1];
+
+    #[test]
+    fn test_mann_whitney_two_sided() {
+        let res = mann_whitney_u(&A, &B, Alternative::TwoSided).unwrap();
+        assert!((res.u_statistic - 22.0).abs() < 1e-12);
+        assert!((res.p_value - 0.19393085228241058).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_mann_whitney_one_sided() {
+        let less = mann_whitney_u(&A, &B, Alternative::Less).unwrap();
+        assert!((less.p_value - 0.09696542614120529).abs() < 1e-10);
+        let greater = mann_whitney_u(&A, &B, Alternative::Greater).unwrap();
+        assert!((greater.p_value - 0.9185317500776713).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_mann_whitney_ties() {
+        let x = [1.0, 2.0, 2.0, 3.0, 4.0];
+        let y = [2.0, 3.0, 3.0, 4.0, 5.0, 6.0];
+        let res = mann_whitney_u(&x, &y, Alternative::TwoSided).unwrap();
+        assert!((res.u_statistic - 6.5).abs() < 1e-12);
+        assert!((res.p_value - 0.13585170221660398).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_mann_whitney_degenerate() {
+        assert!(mann_whitney_u::<f64, f64>(&[], &[1.0], Alternative::TwoSided).is_err());
+        // All identical values → zero rank variance.
+        let c = [3.0, 3.0, 3.0];
+        assert!(mann_whitney_u(&c, &c, Alternative::TwoSided).is_err());
+    }
+}

--- a/src/hypothesis_tests/mod.rs
+++ b/src/hypothesis_tests/mod.rs
@@ -1,12 +1,18 @@
 pub mod anova;
 pub mod chi_square_test;
+pub mod fisher;
+pub mod ks;
 pub mod mann_whitney;
 pub mod t_test;
 pub mod wilcoxon;
 
 // Re-export functions to allow users to import them directly from hypothesis_tests module
 pub use self::anova::one_way_anova;
-pub use self::chi_square_test::{ChiSquareResult, chi_square_goodness_of_fit, chi_square_independence};
+pub use self::chi_square_test::{
+    ChiSquareResult, chi_square_goodness_of_fit, chi_square_independence,
+};
+pub use self::fisher::{FisherExactResult, fisher_exact};
+pub use self::ks::ks_2samp;
 pub use self::mann_whitney::{MannWhitneyResult, mann_whitney_u};
 pub use self::t_test::{
     cohens_d, one_sample_t_test, one_sample_t_test_alt, paired_t_test, paired_t_test_alt,

--- a/src/hypothesis_tests/mod.rs
+++ b/src/hypothesis_tests/mod.rs
@@ -3,6 +3,9 @@ pub mod chi_square_test;
 pub mod fisher;
 pub mod ks;
 pub mod mann_whitney;
+pub mod normality;
+pub mod p_adjust;
+pub mod power;
 pub mod t_test;
 pub mod wilcoxon;
 
@@ -14,6 +17,9 @@ pub use self::chi_square_test::{
 pub use self::fisher::{FisherExactResult, fisher_exact};
 pub use self::ks::ks_2samp;
 pub use self::mann_whitney::{MannWhitneyResult, mann_whitney_u};
+pub use self::normality::{NormalityResult, dagostino_k2};
+pub use self::p_adjust::{PAdjustMethod, p_adjust};
+pub use self::power::{TTestKind, power_t_test, sample_size_t_test};
 pub use self::t_test::{
     cohens_d, one_sample_t_test, one_sample_t_test_alt, paired_t_test, paired_t_test_alt,
     two_sample_t_test, two_sample_t_test_alt,

--- a/src/hypothesis_tests/mod.rs
+++ b/src/hypothesis_tests/mod.rs
@@ -1,8 +1,30 @@
 pub mod anova;
 pub mod chi_square_test;
+pub mod mann_whitney;
 pub mod t_test;
+pub mod wilcoxon;
 
 // Re-export functions to allow users to import them directly from hypothesis_tests module
 pub use self::anova::one_way_anova;
 pub use self::chi_square_test::{chi_square_goodness_of_fit, chi_square_independence};
-pub use self::t_test::{one_sample_t_test, paired_t_test, two_sample_t_test};
+pub use self::mann_whitney::{MannWhitneyResult, mann_whitney_u};
+pub use self::t_test::{
+    cohens_d, one_sample_t_test, one_sample_t_test_alt, paired_t_test, paired_t_test_alt,
+    two_sample_t_test, two_sample_t_test_alt,
+};
+pub use self::wilcoxon::{WilcoxonResult, wilcoxon_signed_rank};
+
+/// Alternative hypothesis for one- and two-sided tests.
+///
+/// Follows the scipy convention: for a two-sample statistic on `(a, b)`,
+/// `Less` means "the first sample is stochastically smaller".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Alternative {
+    /// H₁: the parameter differs from the null value (default).
+    #[default]
+    TwoSided,
+    /// H₁: the parameter is smaller than the null value.
+    Less,
+    /// H₁: the parameter is greater than the null value.
+    Greater,
+}

--- a/src/hypothesis_tests/mod.rs
+++ b/src/hypothesis_tests/mod.rs
@@ -6,7 +6,7 @@ pub mod wilcoxon;
 
 // Re-export functions to allow users to import them directly from hypothesis_tests module
 pub use self::anova::one_way_anova;
-pub use self::chi_square_test::{chi_square_goodness_of_fit, chi_square_independence};
+pub use self::chi_square_test::{ChiSquareResult, chi_square_goodness_of_fit, chi_square_independence};
 pub use self::mann_whitney::{MannWhitneyResult, mann_whitney_u};
 pub use self::t_test::{
     cohens_d, one_sample_t_test, one_sample_t_test_alt, paired_t_test, paired_t_test_alt,

--- a/src/hypothesis_tests/mod.rs
+++ b/src/hypothesis_tests/mod.rs
@@ -16,6 +16,7 @@ pub use self::chi_square_test::{
 };
 pub use self::fisher::{FisherExactResult, fisher_exact};
 pub use self::ks::ks_2samp;
+// Re-export so every test-result type is importable from this module.
 pub use self::mann_whitney::{MannWhitneyResult, mann_whitney_u};
 pub use self::normality::{NormalityResult, dagostino_k2};
 pub use self::p_adjust::{PAdjustMethod, p_adjust};
@@ -25,6 +26,7 @@ pub use self::t_test::{
     two_sample_t_test, two_sample_t_test_alt,
 };
 pub use self::wilcoxon::{WilcoxonResult, wilcoxon_signed_rank};
+pub use crate::distributions::fitting::KsResult;
 
 /// Alternative hypothesis for one- and two-sided tests.
 ///

--- a/src/hypothesis_tests/normality.rs
+++ b/src/hypothesis_tests/normality.rs
@@ -1,0 +1,155 @@
+//! # D'Agostino-Pearson K² normality test
+//!
+//! Omnibus test of the null hypothesis that data come from a normal
+//! distribution, combining a skewness test (D'Agostino 1970) and a
+//! kurtosis test (Anscombe & Glynn 1983): `K² = z₁² + z₂² ~ χ²(2)` under
+//! H₀. Matches `scipy.stats.normaltest` (and `skewtest` / `kurtosistest`)
+//! exactly. Run it before reaching for a t-test — and reach for
+//! [`mann_whitney_u`](crate::hypothesis_tests::mann_whitney_u) when it
+//! rejects.
+
+use crate::error::{StatsError, StatsResult};
+use num_traits::ToPrimitive;
+
+/// Result of the D'Agostino-Pearson normality test.
+#[derive(Debug, Clone, Copy)]
+pub struct NormalityResult {
+    /// K² omnibus statistic (`z₁² + z₂²`).
+    pub statistic: f64,
+    /// p-value from χ²(2): small ⇒ reject normality.
+    pub p_value: f64,
+    /// z-score of the skewness test (sign = direction of the skew).
+    pub skew_z: f64,
+    /// z-score of the kurtosis test (positive = heavier tails than normal).
+    pub kurtosis_z: f64,
+}
+
+/// D'Agostino-Pearson K² test for departure from normality.
+///
+/// Requires `n ≥ 8` (the transformations below are calibrated for that
+/// regime; scipy enforces the same bound).
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::dagostino_k2;
+///
+/// // Right-skewed data with an outlier: normality is rejected.
+/// let x = [2.1, 3.4, 1.8, 2.9, 3.1, 2.5, 4.8, 2.2, 3.0, 2.7,
+///          1.9, 3.3, 2.4, 5.6, 2.8, 3.2, 2.0, 2.6, 3.7, 2.3,
+///          8.1, 3.5, 2.95, 3.05, 2.45];
+/// let res = dagostino_k2(&x).unwrap();
+/// assert!(res.p_value < 1e-4);
+/// ```
+pub fn dagostino_k2<T>(data: &[T]) -> StatsResult<NormalityResult>
+where
+    T: ToPrimitive,
+{
+    let n = data.len();
+    if n < 8 {
+        return Err(StatsError::invalid_input(format!(
+            "dagostino_k2: need at least 8 observations, got {n}"
+        )));
+    }
+    let xs: Vec<f64> = data
+        .iter()
+        .map(|v| v.to_f64())
+        .collect::<Option<_>>()
+        .ok_or_else(|| StatsError::conversion_error("dagostino_k2: data not convertible to f64"))?;
+
+    let nf = n as f64;
+    let mean = xs.iter().sum::<f64>() / nf;
+    let (mut m2, mut m3, mut m4) = (0.0_f64, 0.0_f64, 0.0_f64);
+    for &x in &xs {
+        let d = x - mean;
+        let d2 = d * d;
+        m2 += d2;
+        m3 += d2 * d;
+        m4 += d2 * d2;
+    }
+    m2 /= nf;
+    m3 /= nf;
+    m4 /= nf;
+    if m2 == 0.0 {
+        return Err(StatsError::invalid_input(
+            "dagostino_k2: data has zero variance",
+        ));
+    }
+    let g1 = m3 / m2.powf(1.5); // sample skewness
+    let b2 = m4 / (m2 * m2); // sample kurtosis (not excess)
+
+    // ── Skewness z (D'Agostino 1970, as in scipy.stats.skewtest) ──────
+    let y = g1 * ((nf + 1.0) * (nf + 3.0) / (6.0 * (nf - 2.0))).sqrt();
+    let beta2 = 3.0 * (nf * nf + 27.0 * nf - 70.0) * (nf + 1.0) * (nf + 3.0)
+        / ((nf - 2.0) * (nf + 5.0) * (nf + 7.0) * (nf + 9.0));
+    let w2 = -1.0 + (2.0 * (beta2 - 1.0)).sqrt();
+    let delta = 1.0 / (0.5 * w2.ln()).sqrt();
+    let alpha = (2.0 / (w2 - 1.0)).sqrt();
+    let y = if y == 0.0 { 1e-100 } else { y }; // scipy's guard against ln(0)
+    let ya = y / alpha;
+    let skew_z = delta * (ya + (ya * ya + 1.0).sqrt()).ln();
+
+    // ── Kurtosis z (Anscombe & Glynn 1983, as in scipy.stats.kurtosistest) ──
+    let e = 3.0 * (nf - 1.0) / (nf + 1.0);
+    let var_b2 =
+        24.0 * nf * (nf - 2.0) * (nf - 3.0) / ((nf + 1.0) * (nf + 1.0) * (nf + 3.0) * (nf + 5.0));
+    let x_std = (b2 - e) / var_b2.sqrt();
+    let sqrt_beta1 = 6.0 * (nf * nf - 5.0 * nf + 2.0) / ((nf + 7.0) * (nf + 9.0))
+        * (6.0 * (nf + 3.0) * (nf + 5.0) / (nf * (nf - 2.0) * (nf - 3.0))).sqrt();
+    let a = 6.0
+        + 8.0 / sqrt_beta1 * (2.0 / sqrt_beta1 + (1.0 + 4.0 / (sqrt_beta1 * sqrt_beta1)).sqrt());
+    let term1 = 1.0 - 2.0 / (9.0 * a);
+    let denom = 1.0 + x_std * (2.0 / (a - 4.0)).sqrt();
+    // scipy handles denom < 0 via a signed cbrt.
+    let term2 = ((1.0 - 2.0 / a) / denom.abs()).cbrt() * denom.signum();
+    let kurtosis_z = (term1 - term2) / (2.0 / (9.0 * a)).sqrt();
+
+    // ── Omnibus: K² ~ χ²(2) ⇒ p = exp(−K²/2) exactly ──────────────────
+    let k2 = skew_z * skew_z + kurtosis_z * kurtosis_z;
+    let p_value = (-0.5 * k2).exp().clamp(0.0, 1.0);
+
+    Ok(NormalityResult {
+        statistic: k2,
+        p_value,
+        skew_z,
+        kurtosis_z,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.normaltest / skewtest / kurtosistest.
+    const X: [f64; 25] = [
+        2.1, 3.4, 1.8, 2.9, 3.1, 2.5, 4.8, 2.2, 3.0, 2.7, 1.9, 3.3, 2.4, 5.6, 2.8, 3.2, 2.0, 2.6,
+        3.7, 2.3, 8.1, 3.5, 2.95, 3.05, 2.45,
+    ];
+
+    #[test]
+    fn test_matches_scipy_skewed() {
+        let r = dagostino_k2(&X).unwrap();
+        assert!(
+            (r.statistic - 29.23244472395368).abs() < 1e-10,
+            "{}",
+            r.statistic
+        );
+        assert!((r.p_value - 4.4900924376021633e-7).abs() < 1e-16);
+        assert!((r.skew_z - 4.122491219672165).abs() < 1e-10);
+        assert!((r.kurtosis_z - 3.4982153832603826).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_matches_scipy_linear() {
+        // Evenly-spaced data: platykurtic but symmetric — not rejected at 5%.
+        let y: Vec<f64> = (0..30).map(|i| -2.0 + 4.0 * i as f64 / 29.0).collect();
+        let r = dagostino_k2(&y).unwrap();
+        assert!((r.statistic - 5.419188147156354).abs() < 1e-10);
+        assert!((r.p_value - 0.0665638212454711).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_errors() {
+        assert!(dagostino_k2(&[1.0; 7]).is_err()); // n < 8
+        assert!(dagostino_k2(&[3.0; 20]).is_err()); // zero variance
+    }
+}

--- a/src/hypothesis_tests/p_adjust.rs
+++ b/src/hypothesis_tests/p_adjust.rs
@@ -1,0 +1,142 @@
+//! # Multiple-comparison corrections
+//!
+//! When you run *m* tests, the chance of at least one false positive at
+//! α = 0.05 is `1 − 0.95^m` — 40% for just 10 tests. [`p_adjust`] rescales
+//! p-values so the usual `p < α` decision rule stays valid across the
+//! whole family of tests. Same conventions as R's `p.adjust` /
+//! `scipy.stats.false_discovery_control`.
+
+use crate::error::{StatsError, StatsResult};
+
+/// Correction method for [`p_adjust`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PAdjustMethod {
+    /// Bonferroni: `p·m`, clipped at 1. Controls the family-wise error
+    /// rate (FWER); simplest and most conservative.
+    Bonferroni,
+    /// Holm step-down: uniformly more powerful than Bonferroni while
+    /// controlling the same FWER. A sensible default.
+    #[default]
+    Holm,
+    /// Benjamini-Hochberg step-up: controls the false-discovery rate
+    /// (FDR) instead of the FWER — more discoveries when many tests are
+    /// expected to be non-null (screening, omics, A/B batteries).
+    BenjaminiHochberg,
+}
+
+/// Adjust a family of p-values for multiple comparisons.
+///
+/// Returns adjusted p-values in the **same order** as the input; compare
+/// them to your α directly.
+///
+/// # Errors
+/// Returns an error if `p_values` is empty or contains values outside
+/// `[0, 1]` (or NaN).
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::{p_adjust, PAdjustMethod};
+///
+/// let p = [0.01, 0.04, 0.03, 0.005, 0.2, 0.5];
+/// let adj = p_adjust(&p, PAdjustMethod::Holm).unwrap();
+/// // Two survive at α = 0.05 (vs all four raw ones).
+/// assert_eq!(adj.iter().filter(|&&q| q < 0.05).count(), 1);
+/// assert!((adj[3] - 0.03).abs() < 1e-12);
+/// ```
+pub fn p_adjust(p_values: &[f64], method: PAdjustMethod) -> StatsResult<Vec<f64>> {
+    if p_values.is_empty() {
+        return Err(StatsError::empty_data(
+            "p_adjust: p_values must not be empty",
+        ));
+    }
+    if p_values.iter().any(|&p| !(0.0..=1.0).contains(&p)) {
+        return Err(StatsError::invalid_input(
+            "p_adjust: all p-values must be in [0, 1]",
+        ));
+    }
+
+    let m = p_values.len();
+    let mf = m as f64;
+    let mut order: Vec<usize> = (0..m).collect();
+    let mut adjusted = vec![0.0_f64; m];
+
+    match method {
+        PAdjustMethod::Bonferroni => {
+            for (a, &p) in adjusted.iter_mut().zip(p_values) {
+                *a = (p * mf).min(1.0);
+            }
+        }
+        PAdjustMethod::Holm => {
+            // Ascending; running max of (m − rank)·p keeps monotonicity.
+            order.sort_by(|&a, &b| {
+                p_values[a]
+                    .partial_cmp(&p_values[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let mut running_max = 0.0_f64;
+            for (rank, &i) in order.iter().enumerate() {
+                running_max = running_max.max((mf - rank as f64) * p_values[i]);
+                adjusted[i] = running_max.min(1.0);
+            }
+        }
+        PAdjustMethod::BenjaminiHochberg => {
+            // Descending; running min of p·m/rank keeps monotonicity.
+            order.sort_by(|&a, &b| {
+                p_values[b]
+                    .partial_cmp(&p_values[a])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let mut running_min = 1.0_f64;
+            for (idx, &i) in order.iter().enumerate() {
+                let rank = (m - idx) as f64; // m, m−1, …, 1
+                running_min = running_min.min(p_values[i] * mf / rank);
+                adjusted[i] = running_min;
+            }
+        }
+    }
+
+    Ok(adjusted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const P: [f64; 6] = [0.01, 0.04, 0.03, 0.005, 0.2, 0.5];
+
+    fn close(a: &[f64], b: &[f64]) {
+        for (x, y) in a.iter().zip(b) {
+            assert!((x - y).abs() < 1e-12, "{a:?} != {b:?}");
+        }
+    }
+
+    #[test]
+    fn test_bonferroni() {
+        let adj = p_adjust(&P, PAdjustMethod::Bonferroni).unwrap();
+        close(&adj, &[0.06, 0.24, 0.18, 0.03, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn test_holm_matches_r() {
+        // Reference: R p.adjust(method = "holm").
+        let adj = p_adjust(&P, PAdjustMethod::Holm).unwrap();
+        close(&adj, &[0.05, 0.12, 0.12, 0.03, 0.4, 0.5]);
+    }
+
+    #[test]
+    fn test_bh_matches_scipy() {
+        // Reference: scipy.stats.false_discovery_control(method='bh').
+        let adj = p_adjust(&P, PAdjustMethod::BenjaminiHochberg).unwrap();
+        close(&adj, &[0.03, 0.06, 0.06, 0.03, 0.24, 0.5]);
+    }
+
+    #[test]
+    fn test_errors_and_edge() {
+        assert!(p_adjust(&[], PAdjustMethod::Holm).is_err());
+        assert!(p_adjust(&[0.5, 1.2], PAdjustMethod::Holm).is_err());
+        assert!(p_adjust(&[0.5, f64::NAN], PAdjustMethod::Holm).is_err());
+        // Single test: no correction.
+        let adj = p_adjust(&[0.04], PAdjustMethod::Holm).unwrap();
+        assert!((adj[0] - 0.04).abs() < 1e-15);
+    }
+}

--- a/src/hypothesis_tests/p_adjust.rs
+++ b/src/hypothesis_tests/p_adjust.rs
@@ -39,7 +39,7 @@ pub enum PAdjustMethod {
 ///
 /// let p = [0.01, 0.04, 0.03, 0.005, 0.2, 0.5];
 /// let adj = p_adjust(&p, PAdjustMethod::Holm).unwrap();
-/// // Two survive at α = 0.05 (vs all four raw ones).
+/// // Only the smallest raw p survives at α = 0.05 (vs four raw ones).
 /// assert_eq!(adj.iter().filter(|&&q| q < 0.05).count(), 1);
 /// assert!((adj[3] - 0.03).abs() < 1e-12);
 /// ```

--- a/src/hypothesis_tests/power.rs
+++ b/src/hypothesis_tests/power.rs
@@ -1,0 +1,208 @@
+//! # Statistical power & sample-size calculations for t-tests
+//!
+//! "How many observations do I need to detect an effect of size d?" —
+//! answered **exactly** through the noncentral t distribution (like
+//! G*Power and `statsmodels.stats.power`), not a normal approximation.
+//!
+//! Effect size is Cohen's d (0.2 small, 0.5 medium, 0.8 large); see
+//! [`cohens_d`](crate::hypothesis_tests::cohens_d) to estimate it from
+//! pilot data.
+
+use crate::distributions::student_t::StudentT;
+use crate::distributions::traits::Distribution as _;
+use crate::error::{StatsError, StatsResult};
+use crate::hypothesis_tests::Alternative;
+use crate::utils::special_functions::{noncentral_t_cdf, noncentral_t_sf};
+
+/// Which t-test the power calculation refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TTestKind {
+    /// One sample against a fixed mean; `n` = number of observations.
+    OneSample,
+    /// Two independent samples (equal sizes); `n` = observations **per group**.
+    TwoSample,
+    /// Paired samples; `n` = number of pairs, `effect_size` = d of the differences.
+    Paired,
+}
+
+fn df_and_ncp(kind: TTestKind, n: u64, d: f64) -> (f64, f64) {
+    let nf = n as f64;
+    match kind {
+        TTestKind::TwoSample => (2.0 * nf - 2.0, d * (nf / 2.0).sqrt()),
+        TTestKind::OneSample | TTestKind::Paired => (nf - 1.0, d * nf.sqrt()),
+    }
+}
+
+fn min_n(kind: TTestKind) -> u64 {
+    match kind {
+        TTestKind::TwoSample => 2,
+        _ => 2,
+    }
+}
+
+/// Exact power of a t-test: the probability of rejecting H₀ at level
+/// `alpha` when the true standardized effect is `effect_size`.
+///
+/// # Errors
+/// Returns an error for `n` too small (df ≤ 0), `alpha` outside (0, 1),
+/// or a non-finite effect size.
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::{power_t_test, Alternative, TTestKind};
+///
+/// // 30 subjects per arm, medium effect: badly underpowered.
+/// let p = power_t_test(TTestKind::TwoSample, 30, 0.5, 0.05, Alternative::TwoSided).unwrap();
+/// assert!((p - 0.478).abs() < 0.001);
+/// ```
+pub fn power_t_test(
+    kind: TTestKind,
+    n: u64,
+    effect_size: f64,
+    alpha: f64,
+    alternative: Alternative,
+) -> StatsResult<f64> {
+    if !(0.0 < alpha && alpha < 1.0) {
+        return Err(StatsError::invalid_parameter(format!(
+            "power_t_test: alpha must be in (0, 1), got {alpha}"
+        )));
+    }
+    if !effect_size.is_finite() {
+        return Err(StatsError::invalid_input(
+            "power_t_test: effect_size must be finite",
+        ));
+    }
+    if n < min_n(kind) {
+        return Err(StatsError::invalid_input(format!(
+            "power_t_test: n = {n} is too small for this design"
+        )));
+    }
+
+    let (df, ncp) = df_and_ncp(kind, n, effect_size);
+    let t = StudentT::new(0.0, 1.0, df)?;
+    let power = match alternative {
+        Alternative::TwoSided => {
+            let t_crit = t.inverse_cdf(1.0 - alpha / 2.0)?;
+            noncentral_t_sf(t_crit, df, ncp) + noncentral_t_cdf(-t_crit, df, ncp)
+        }
+        Alternative::Greater => {
+            let t_crit = t.inverse_cdf(1.0 - alpha)?;
+            noncentral_t_sf(t_crit, df, ncp)
+        }
+        Alternative::Less => {
+            let t_crit = t.inverse_cdf(alpha)?;
+            noncentral_t_cdf(t_crit, df, ncp)
+        }
+    };
+    Ok(power.clamp(0.0, 1.0))
+}
+
+/// Smallest `n` (per group for [`TTestKind::TwoSample`]) reaching the
+/// target `power` for the given effect size and level.
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::{sample_size_t_test, Alternative, TTestKind};
+///
+/// // The classic: d = 0.5, 80% power, two-sided α = 0.05 → 64 per group.
+/// let n = sample_size_t_test(TTestKind::TwoSample, 0.5, 0.05, 0.8, Alternative::TwoSided).unwrap();
+/// assert_eq!(n, 64);
+/// ```
+pub fn sample_size_t_test(
+    kind: TTestKind,
+    effect_size: f64,
+    alpha: f64,
+    power: f64,
+    alternative: Alternative,
+) -> StatsResult<u64> {
+    if !(0.0 < power && power < 1.0) {
+        return Err(StatsError::invalid_parameter(format!(
+            "sample_size_t_test: power must be in (0, 1), got {power}"
+        )));
+    }
+    if effect_size == 0.0 || !effect_size.is_finite() {
+        return Err(StatsError::invalid_input(
+            "sample_size_t_test: effect_size must be non-zero and finite",
+        ));
+    }
+
+    // Exponential search for an upper bound, then binary search for the
+    // minimal n. Power is monotone in n for a fixed effect.
+    let mut lo = min_n(kind);
+    let mut hi = lo;
+    while power_t_test(kind, hi, effect_size, alpha, alternative)? < power {
+        hi = hi.saturating_mul(2);
+        if hi > 100_000_000 {
+            return Err(StatsError::invalid_input(
+                "sample_size_t_test: required n exceeds 1e8 — effect size too small",
+            ));
+        }
+    }
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if power_t_test(kind, mid, effect_size, alpha, alternative)? < power {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    Ok(lo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::special_functions::noncentral_t_cdf as nct_cdf;
+
+    #[test]
+    fn test_noncentral_t_matches_scipy() {
+        // Reference: scipy.stats.nct.cdf.
+        for (t, df, nc, expected) in [
+            (1.5, 10.0, 2.0, 0.3047854473760423),
+            (-0.5, 5.0, 1.0, 0.07230224347690409),
+            (3.0, 20.0, 2.5, 0.6616028734935053),
+            (0.0, 8.0, 0.5, 0.3085375387259869),
+            (2.0, 3.0, -1.5, 0.9971191699279385),
+        ] {
+            let got = nct_cdf(t, df, nc);
+            assert!(
+                (got - expected).abs() < 1e-10,
+                "nct_cdf({t}, {df}, {nc}) = {got}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_power_matches_scipy() {
+        // References computed with scipy.stats.nct (same as statsmodels).
+        let p = power_t_test(TTestKind::TwoSample, 30, 0.5, 0.05, Alternative::TwoSided).unwrap();
+        assert!((p - 0.4778965207601648).abs() < 1e-9, "{p}");
+        let p = power_t_test(TTestKind::TwoSample, 64, 0.5, 0.05, Alternative::TwoSided).unwrap();
+        assert!((p - 0.8014595579222545).abs() < 1e-9, "{p}");
+        let p = power_t_test(TTestKind::OneSample, 20, 0.6, 0.05, Alternative::TwoSided).unwrap();
+        assert!((p - 0.7210050995594134).abs() < 1e-9, "{p}");
+        let p = power_t_test(TTestKind::TwoSample, 20, 0.5, 0.05, Alternative::Greater).unwrap();
+        assert!((p - 0.4633743492964092).abs() < 1e-9, "{p}");
+    }
+
+    #[test]
+    fn test_sample_size_classic() {
+        // d = 0.5, 80% power, α = 0.05 two-sided → 64/group (statsmodels: 63.77).
+        let n = sample_size_t_test(TTestKind::TwoSample, 0.5, 0.05, 0.8, Alternative::TwoSided)
+            .unwrap();
+        assert_eq!(n, 64);
+        // Boundary sanity: n−1 must be underpowered.
+        let p63 = power_t_test(TTestKind::TwoSample, 63, 0.5, 0.05, Alternative::TwoSided).unwrap();
+        assert!(p63 < 0.8);
+    }
+
+    #[test]
+    fn test_errors() {
+        assert!(power_t_test(TTestKind::TwoSample, 1, 0.5, 0.05, Alternative::TwoSided).is_err());
+        assert!(power_t_test(TTestKind::TwoSample, 30, 0.5, 1.5, Alternative::TwoSided).is_err());
+        assert!(
+            sample_size_t_test(TTestKind::TwoSample, 0.0, 0.05, 0.8, Alternative::TwoSided)
+                .is_err()
+        );
+    }
+}

--- a/src/hypothesis_tests/power.rs
+++ b/src/hypothesis_tests/power.rs
@@ -33,12 +33,8 @@ fn df_and_ncp(kind: TTestKind, n: u64, d: f64) -> (f64, f64) {
     }
 }
 
-fn min_n(kind: TTestKind) -> u64 {
-    match kind {
-        TTestKind::TwoSample => 2,
-        _ => 2,
-    }
-}
+/// Every design needs at least 2 observations (df ≥ 1).
+const MIN_N: u64 = 2;
 
 /// Exact power of a t-test: the probability of rejecting H₀ at level
 /// `alpha` when the true standardized effect is `effect_size`.
@@ -72,7 +68,7 @@ pub fn power_t_test(
             "power_t_test: effect_size must be finite",
         ));
     }
-    if n < min_n(kind) {
+    if n < MIN_N {
         return Err(StatsError::invalid_input(format!(
             "power_t_test: n = {n} is too small for this design"
         )));
@@ -128,7 +124,7 @@ pub fn sample_size_t_test(
 
     // Exponential search for an upper bound, then binary search for the
     // minimal n. Power is monotone in n for a fixed effect.
-    let mut lo = min_n(kind);
+    let mut lo = MIN_N;
     let mut hi = lo;
     while power_t_test(kind, hi, effect_size, alpha, alternative)? < power {
         hi = hi.saturating_mul(2);

--- a/src/hypothesis_tests/t_test.rs
+++ b/src/hypothesis_tests/t_test.rs
@@ -17,6 +17,7 @@
 //! uncertainty from estimating the standard deviation.
 
 use crate::error::{StatsError, StatsResult};
+use crate::hypothesis_tests::Alternative;
 use crate::utils::special_functions::regularized_incomplete_beta;
 use num_traits::ToPrimitive;
 use std::f64;
@@ -29,7 +30,8 @@ pub struct TTestResult {
     pub t_statistic: f64,
     /// Degrees of freedom for the t-distribution
     pub degrees_of_freedom: f64,
-    /// The two-tailed p-value
+    /// The p-value — two-tailed for the base functions, or under the
+    /// requested [`Alternative`] for the `*_alt` variants.
     pub p_value: f64,
     /// The sample mean(s)
     pub mean_values: Vec<f64>,
@@ -39,15 +41,64 @@ pub struct TTestResult {
     pub std_error: f64,
 }
 
+impl TTestResult {
+    /// The point estimate the test was built around: the sample mean
+    /// (one-sample), the difference of means (two-sample), or the mean
+    /// pairwise difference (paired).
+    pub fn estimate(&self) -> f64 {
+        match self.mean_values.len() {
+            2 => self.mean_values[0] - self.mean_values[1],
+            // one-sample: [mean]; paired: [mean_diff, mean1, mean2].
+            _ => self.mean_values[0],
+        }
+    }
+
+    /// Two-sided confidence interval for [`estimate`](Self::estimate):
+    /// `estimate ± t₍df₎(½(1+level)) · std_error`.
+    ///
+    /// # Errors
+    /// Returns `StatsError::InvalidParameter` if `level` is not in (0, 1).
+    pub fn confidence_interval(&self, level: f64) -> StatsResult<(f64, f64)> {
+        if !(0.0 < level && level < 1.0) {
+            return Err(StatsError::invalid_parameter(format!(
+                "confidence_interval: level must be in (0, 1), got {level}"
+            )));
+        }
+        use crate::distributions::student_t::StudentT;
+        use crate::distributions::traits::Distribution as _;
+        let t_crit =
+            StudentT::new(0.0, 1.0, self.degrees_of_freedom)?.inverse_cdf(0.5 * (1.0 + level))?;
+        let margin = t_crit * self.std_error;
+        let est = self.estimate();
+        Ok((est - margin, est + margin))
+    }
+}
+
+/// Survival function of Student-t: `P(T > t)` with `df` degrees of freedom.
+fn t_sf(t: f64, df: f64) -> f64 {
+    let ib = regularized_incomplete_beta(df / 2.0, 0.5, df / (t * t + df));
+    if t >= 0.0 { 0.5 * ib } else { 1.0 - 0.5 * ib }
+}
+
+/// p-value of `t` under the requested alternative.
+fn t_p_value(t: f64, df: f64, alternative: Alternative) -> f64 {
+    match alternative {
+        Alternative::TwoSided => calculate_p_value(t.abs(), df),
+        Alternative::Greater => t_sf(t, df),
+        Alternative::Less => 1.0 - t_sf(t, df),
+    }
+}
+
 /// Performs a one-sample t-test to determine if a sample mean differs from a specified population mean.
 ///
 /// # Arguments
 /// * `data` - The sample data
 /// * `population_mean` - The population mean to test against
-/// * `alpha` - The significance level (default: 0.05)
 ///
 /// # Returns
-/// A `Result` containing the t-test results or an error if the data is insufficient
+/// A `Result` containing the t-test results (two-sided p-value) or an error
+/// if the data is insufficient. For one-sided alternatives use
+/// [`one_sample_t_test_alt`].
 ///
 /// # Examples
 /// ```
@@ -424,6 +475,93 @@ fn calculate_p_value(t_stat: f64, df: f64) -> f64 {
     let t2 = t_stat * t_stat;
     let x = df / (df + t2);
     regularized_incomplete_beta(0.5 * df, 0.5, x).clamp(0.0, 1.0)
+}
+
+// ── One-sided variants ─────────────────────────────────────────────────────────
+
+/// [`one_sample_t_test`] with a choice of [`Alternative`].
+///
+/// `Alternative::Greater` tests H₁: mean > `population_mean`.
+pub fn one_sample_t_test_alt<T>(
+    data: &[T],
+    population_mean: T,
+    alternative: Alternative,
+) -> StatsResult<TTestResult>
+where
+    T: ToPrimitive + Debug + Copy,
+{
+    let mut res = one_sample_t_test(data, population_mean)?;
+    res.p_value = t_p_value(res.t_statistic, res.degrees_of_freedom, alternative);
+    Ok(res)
+}
+
+/// [`two_sample_t_test`] with a choice of [`Alternative`].
+///
+/// `Alternative::Less` tests H₁: mean(data1) < mean(data2) (scipy convention).
+pub fn two_sample_t_test_alt<T>(
+    data1: &[T],
+    data2: &[T],
+    equal_variances: bool,
+    alternative: Alternative,
+) -> StatsResult<TTestResult>
+where
+    T: ToPrimitive + Debug + Copy,
+{
+    let mut res = two_sample_t_test(data1, data2, equal_variances)?;
+    res.p_value = t_p_value(res.t_statistic, res.degrees_of_freedom, alternative);
+    Ok(res)
+}
+
+/// [`paired_t_test`] with a choice of [`Alternative`].
+///
+/// `Alternative::Greater` tests H₁: mean(data1 − data2) > 0.
+pub fn paired_t_test_alt<T>(
+    data1: &[T],
+    data2: &[T],
+    alternative: Alternative,
+) -> StatsResult<TTestResult>
+where
+    T: ToPrimitive + Debug + Copy,
+{
+    let mut res = paired_t_test(data1, data2)?;
+    res.p_value = t_p_value(res.t_statistic, res.degrees_of_freedom, alternative);
+    Ok(res)
+}
+
+// ── Effect size ────────────────────────────────────────────────────────────────
+
+/// Cohen's d effect size for two independent samples, using the pooled
+/// sample standard deviation:
+/// `d = (mean₁ − mean₂) / √(((n₁−1)s₁² + (n₂−1)s₂²)/(n₁+n₂−2))`.
+///
+/// Rule-of-thumb magnitudes: 0.2 small, 0.5 medium, 0.8 large.
+///
+/// # Errors
+/// Returns an error if either sample has fewer than 2 points or the pooled
+/// variance is zero.
+pub fn cohens_d<T, U>(data1: &[T], data2: &[U]) -> StatsResult<f64>
+where
+    T: ToPrimitive + Debug + Copy,
+    U: ToPrimitive + Debug + Copy,
+{
+    if data1.len() < 2 || data2.len() < 2 {
+        return Err(StatsError::invalid_input(
+            "cohens_d: need at least 2 points per sample",
+        ));
+    }
+    let m1 = calculate_mean(data1)?;
+    let m2 = calculate_mean(data2)?;
+    let v1 = calculate_variance(data1, m1)?;
+    let v2 = calculate_variance(data2, m2)?;
+    let n1 = data1.len() as f64;
+    let n2 = data2.len() as f64;
+    let pooled = ((n1 - 1.0) * v1 + (n2 - 1.0) * v2) / (n1 + n2 - 2.0);
+    if pooled <= 0.0 {
+        return Err(StatsError::invalid_input(
+            "cohens_d: zero pooled variance; the effect size is undefined",
+        ));
+    }
+    Ok((m1 - m2) / pooled.sqrt())
 }
 
 #[cfg(test)]

--- a/src/hypothesis_tests/t_test.rs
+++ b/src/hypothesis_tests/t_test.rs
@@ -93,6 +93,11 @@ where
     let variance = calculate_variance(data, mean)?;
     let std_dev = variance.sqrt();
     let std_error = std_dev / n.sqrt();
+    if std_error == 0.0 {
+        return Err(StatsError::invalid_input(
+            "one_sample_t_test: data has zero variance; the t-statistic is undefined",
+        ));
+    }
 
     // Calculate t-statistic
     let t_statistic = (mean - pop_mean) / std_error;
@@ -181,6 +186,11 @@ where
         // Pooled variance formula for equal variances (Student's t-test)
         let pooled_variance = ((n1 - 1.0) * var1 + (n2 - 1.0) * var2) / (n1 + n2 - 2.0);
         std_error = (pooled_variance * (1.0 / n1 + 1.0 / n2)).sqrt();
+        if std_error == 0.0 {
+            return Err(StatsError::invalid_input(
+                "two_sample_t_test: both samples have zero variance; the t-statistic is undefined",
+            ));
+        }
         t_statistic = (mean1 - mean2) / std_error;
         degrees_of_freedom = n1 + n2 - 2.0;
     } else {
@@ -188,6 +198,11 @@ where
         let var1_n1 = var1 / n1;
         let var2_n2 = var2 / n2;
         std_error = (var1_n1 + var2_n2).sqrt();
+        if std_error == 0.0 {
+            return Err(StatsError::invalid_input(
+                "two_sample_t_test: both samples have zero variance; the t-statistic is undefined",
+            ));
+        }
         t_statistic = (mean1 - mean2) / std_error;
 
         // Welch-Satterthwaite equation for degrees of freedom
@@ -313,6 +328,11 @@ where
     let variance = diff_m2 / (n - 1.0);
     let std_dev = variance.sqrt();
     let std_error = std_dev / n.sqrt();
+    if std_error == 0.0 {
+        return Err(StatsError::invalid_input(
+            "paired_t_test: the pairwise differences have zero variance; the t-statistic is undefined",
+        ));
+    }
 
     // Calculate t-statistic for paired test
     let t_statistic = mean_diff / std_error;

--- a/src/hypothesis_tests/wilcoxon.rs
+++ b/src/hypothesis_tests/wilcoxon.rs
@@ -1,0 +1,184 @@
+//! # Wilcoxon signed-rank test
+//!
+//! Non-parametric test for paired samples (or one sample against zero).
+//! Uses the normal approximation with tie correction — matching
+//! `scipy.stats.wilcoxon(zero_method="wilcox", correction=False,
+//! method="approx")`. Appropriate for `n ≳ 10` non-zero pairs.
+
+use crate::error::{StatsError, StatsResult};
+use crate::hypothesis_tests::Alternative;
+use crate::prob::erfc;
+use crate::utils::numeric::average_ranks;
+use num_traits::ToPrimitive;
+
+/// Result of a Wilcoxon signed-rank test.
+#[derive(Debug, Clone, Copy)]
+pub struct WilcoxonResult {
+    /// Sum of ranks of the positive differences (`W⁺`).
+    pub w_plus: f64,
+    /// Sum of ranks of the negative differences (`W⁻`).
+    pub w_minus: f64,
+    /// The test statistic as reported by scipy: `min(W⁺, W⁻)` for
+    /// [`Alternative::TwoSided`], `W⁺` otherwise.
+    pub statistic: f64,
+    /// Standard-normal z used for the p-value.
+    pub z_score: f64,
+    /// p-value under the chosen [`Alternative`].
+    pub p_value: f64,
+    /// Number of non-zero pairs actually used.
+    pub n_used: usize,
+}
+
+fn norm_sf(z: f64) -> f64 {
+    0.5 * erfc(z / std::f64::consts::SQRT_2).unwrap_or(f64::NAN)
+}
+
+/// Wilcoxon signed-rank test on paired samples.
+///
+/// Zero differences are dropped (`zero_method="wilcox"`), ties among the
+/// absolute differences get average ranks with the usual variance
+/// correction. `Alternative::Greater` means "`a` tends to be larger
+/// than `b`".
+///
+/// # Errors
+/// Returns an error on length mismatch, or when no non-zero difference
+/// remains (all pairs equal).
+///
+/// # Examples
+/// ```
+/// use rs_stats::hypothesis_tests::{Alternative, wilcoxon_signed_rank};
+///
+/// let before = [125.0, 115.0, 130.0, 140.0, 140.0, 115.0, 140.0, 125.0, 140.0, 135.0];
+/// let after  = [110.0, 122.0, 125.0, 120.0, 140.0, 124.0, 123.0, 137.0, 135.0, 145.0];
+/// let res = wilcoxon_signed_rank(&before, &after, Alternative::TwoSided).unwrap();
+/// assert!(res.p_value > 0.05);
+/// ```
+pub fn wilcoxon_signed_rank<X, Y>(
+    a: &[X],
+    b: &[Y],
+    alternative: Alternative,
+) -> StatsResult<WilcoxonResult>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    if a.len() != b.len() {
+        return Err(StatsError::dimension_mismatch(format!(
+            "wilcoxon_signed_rank: samples must have the same length (got {} and {})",
+            a.len(),
+            b.len()
+        )));
+    }
+    if a.is_empty() {
+        return Err(StatsError::invalid_input(
+            "wilcoxon_signed_rank: samples must be non-empty",
+        ));
+    }
+
+    // Differences, dropping zeros (zero_method = "wilcox").
+    let mut diffs: Vec<f64> = Vec::with_capacity(a.len());
+    for (x, y) in a.iter().zip(b) {
+        let xv = x.to_f64().ok_or_else(|| {
+            StatsError::conversion_error("wilcoxon_signed_rank: a not convertible to f64")
+        })?;
+        let yv = y.to_f64().ok_or_else(|| {
+            StatsError::conversion_error("wilcoxon_signed_rank: b not convertible to f64")
+        })?;
+        let d = xv - yv;
+        if d != 0.0 {
+            diffs.push(d);
+        }
+    }
+    let n = diffs.len();
+    if n == 0 {
+        return Err(StatsError::invalid_input(
+            "wilcoxon_signed_rank: all pairs are equal; the test is undefined",
+        ));
+    }
+
+    let abs_diffs: Vec<f64> = diffs.iter().map(|d| d.abs()).collect();
+    let ranks = average_ranks(&abs_diffs);
+    let w_plus: f64 = diffs
+        .iter()
+        .zip(&ranks)
+        .filter(|(d, _)| **d > 0.0)
+        .map(|(_, r)| r)
+        .sum();
+    let total = (n * (n + 1)) as f64 / 2.0;
+    let w_minus = total - w_plus;
+
+    // Tie-corrected variance: n(n+1)(2n+1)/24 − Σ(t³−t)/48.
+    let mut sorted = abs_diffs;
+    sorted.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    let mut tie_term = 0.0_f64;
+    let mut i = 0;
+    while i < n {
+        let mut j = i + 1;
+        while j < n && sorted[j] == sorted[i] {
+            j += 1;
+        }
+        let t = (j - i) as f64;
+        tie_term += t * t * t - t;
+        i = j;
+    }
+    let nf = n as f64;
+    let mu = nf * (nf + 1.0) / 4.0;
+    let sigma_sq = nf * (nf + 1.0) * (2.0 * nf + 1.0) / 24.0 - tie_term / 48.0;
+    if sigma_sq <= 0.0 {
+        return Err(StatsError::invalid_input(
+            "wilcoxon_signed_rank: zero rank variance; the test is undefined",
+        ));
+    }
+    let z = (w_plus - mu) / sigma_sq.sqrt();
+
+    let (statistic, p_value) = match alternative {
+        Alternative::TwoSided => (w_plus.min(w_minus), (2.0 * norm_sf(z.abs())).min(1.0)),
+        Alternative::Greater => (w_plus, norm_sf(z)),
+        Alternative::Less => (w_plus, 1.0 - norm_sf(z)),
+    };
+
+    Ok(WilcoxonResult {
+        w_plus,
+        w_minus,
+        statistic,
+        z_score: z,
+        p_value,
+        n_used: n,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scipy.stats.wilcoxon(method='approx').
+    const A: [f64; 10] = [
+        125.0, 115.0, 130.0, 140.0, 140.0, 115.0, 140.0, 125.0, 140.0, 135.0,
+    ];
+    const B: [f64; 10] = [
+        110.0, 122.0, 125.0, 120.0, 140.0, 124.0, 123.0, 137.0, 135.0, 145.0,
+    ];
+
+    #[test]
+    fn test_wilcoxon_two_sided() {
+        let res = wilcoxon_signed_rank(&A, &B, Alternative::TwoSided).unwrap();
+        // One zero pair is dropped → n = 9; statistic = min(W+, W−) = 18.
+        assert_eq!(res.n_used, 9);
+        assert!((res.statistic - 18.0).abs() < 1e-12);
+        assert!((res.p_value - 0.5936305914425295).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_wilcoxon_greater() {
+        let res = wilcoxon_signed_rank(&A, &B, Alternative::Greater).unwrap();
+        assert!((res.statistic - 27.0).abs() < 1e-12);
+        assert!((res.p_value - 0.29681529572126475).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_wilcoxon_degenerate() {
+        let x = [1.0, 2.0, 3.0];
+        assert!(wilcoxon_signed_rank(&x, &x, Alternative::TwoSided).is_err());
+        assert!(wilcoxon_signed_rank(&x, &[1.0], Alternative::TwoSided).is_err());
+    }
+}

--- a/src/hypothesis_tests/wilcoxon.rs
+++ b/src/hypothesis_tests/wilcoxon.rs
@@ -85,6 +85,11 @@ where
             StatsError::conversion_error("wilcoxon_signed_rank: b not convertible to f64")
         })?;
         let d = xv - yv;
+        if d.is_nan() {
+            return Err(StatsError::invalid_input(
+                "wilcoxon_signed_rank: samples contain NaN",
+            ));
+        }
         if d != 0.0 {
             diffs.push(d);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 //!
 //! | Module | Contents |
 //! |--------|----------|
-//! | [`distributions`] | 14 distributions + unified trait interface + auto-fit API |
-//! | [`hypothesis_tests`] | t-tests, ANOVA, chi-square, chi-square independence |
-//! | [`regression`] | Linear, multiple linear, decision trees |
-//! | [`prob`] | Mean, variance, std-dev, z-scores, erf, CDF helpers |
+//! | [`distributions`] | 14 distributions + unified trait (pdf/cdf/sf/quantile/sample) + auto-fit API |
+//! | [`hypothesis_tests`] | t-tests (one/two-sided + CI), ANOVA, chi-square, Mann-Whitney U, Wilcoxon |
+//! | [`regression`] | Linear (CI + prediction intervals), multiple linear (per-coefficient inference), decision trees |
+//! | [`prob`] | Mean, variance, std-dev, z-scores, erf/erfc, Pearson/Spearman correlation |
 //! | [`utils`] | Special functions (`ln_gamma`, incomplete gamma/beta), combinatorics |
 //!
 //! ## Medical Quick-Start

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub mod error;
 pub mod hypothesis_tests;
 pub mod prob;
 pub mod regression;
+pub mod resampling;
 pub mod utils;
 
 // Re-export error types for convenience

--- a/src/prob/average.rs
+++ b/src/prob/average.rs
@@ -60,17 +60,33 @@ where
         ));
     }
 
-    let mut sum = 0.0;
-
-    for (i, x) in data.iter().enumerate() {
-        let v = x.to_f64().ok_or_else(|| {
+    // Four independent accumulators: a single `sum += v` is a loop-carried
+    // dependency that caps the loop at one FP add per ~4 cycles and blocks
+    // vectorisation (FP addition is not associative, so LLVM cannot split
+    // the chain itself). Four lanes let the adds pipeline/vectorise; the
+    // summation-order change moves the result by at most a few ulp.
+    let mut acc = [0.0_f64; 4];
+    let mut chunks = data.chunks_exact(4);
+    let mut idx = 0usize;
+    let conv = |x: &T, i: usize| {
+        x.to_f64().ok_or_else(|| {
             StatsError::conversion_error(format!(
                 "prob::average: Failed to convert value at index {} to f64",
                 i
             ))
-        })?;
-
-        sum += v;
+        })
+    };
+    for chunk in chunks.by_ref() {
+        acc[0] += conv(&chunk[0], idx)?;
+        acc[1] += conv(&chunk[1], idx + 1)?;
+        acc[2] += conv(&chunk[2], idx + 2)?;
+        acc[3] += conv(&chunk[3], idx + 3)?;
+        idx += 4;
+    }
+    let mut sum = (acc[0] + acc[1]) + (acc[2] + acc[3]);
+    for x in chunks.remainder() {
+        sum += conv(x, idx)?;
+        idx += 1;
     }
 
     Ok(sum / data.len() as f64)

--- a/src/prob/correlation.rs
+++ b/src/prob/correlation.rs
@@ -55,6 +55,11 @@ where
         .ok_or_else(|| {
             StatsError::conversion_error(format!("{caller}: y not convertible to f64"))
         })?;
+    if xf.iter().chain(yf.iter()).any(|v| v.is_nan()) {
+        return Err(StatsError::invalid_input(format!(
+            "{caller}: data contains NaN"
+        )));
+    }
     Ok((xf, yf))
 }
 

--- a/src/prob/correlation.rs
+++ b/src/prob/correlation.rs
@@ -1,0 +1,243 @@
+//! # Correlation coefficients
+//!
+//! Pearson (linear) and Spearman (rank) correlation, each with a
+//! two-sided significance test based on the Student-t approximation
+//! `t = r·√((n−2)/(1−r²))` — the same conventions as
+//! `scipy.stats.pearsonr` / `spearmanr`.
+
+use crate::error::{StatsError, StatsResult};
+use crate::utils::numeric::average_ranks;
+use crate::utils::special_functions::regularized_incomplete_beta;
+use num_traits::ToPrimitive;
+
+/// Result of a correlation significance test.
+#[derive(Debug, Clone, Copy)]
+pub struct CorrelationTest {
+    /// Correlation coefficient in [−1, 1].
+    pub r: f64,
+    /// Student-t statistic `r·√((n−2)/(1−r²))`.
+    pub t_statistic: f64,
+    /// Two-sided p-value (H₀: no correlation).
+    pub p_value: f64,
+    /// Sample size.
+    pub n: usize,
+}
+
+fn to_f64_pairs<X, Y>(x: &[X], y: &[Y], caller: &str) -> StatsResult<(Vec<f64>, Vec<f64>)>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    if x.len() != y.len() {
+        return Err(StatsError::dimension_mismatch(format!(
+            "{caller}: x and y must have the same length (got {} and {})",
+            x.len(),
+            y.len()
+        )));
+    }
+    if x.len() < 2 {
+        return Err(StatsError::invalid_input(format!(
+            "{caller}: need at least 2 paired observations, got {}",
+            x.len()
+        )));
+    }
+    let xf = x
+        .iter()
+        .map(|v| v.to_f64())
+        .collect::<Option<Vec<f64>>>()
+        .ok_or_else(|| StatsError::conversion_error(format!("{caller}: x not convertible to f64")))?;
+    let yf = y
+        .iter()
+        .map(|v| v.to_f64())
+        .collect::<Option<Vec<f64>>>()
+        .ok_or_else(|| StatsError::conversion_error(format!("{caller}: y not convertible to f64")))?;
+    Ok((xf, yf))
+}
+
+fn pearson_f64(x: &[f64], y: &[f64], caller: &str) -> StatsResult<f64> {
+    let n = x.len() as f64;
+    let mean_x = x.iter().sum::<f64>() / n;
+    let mean_y = y.iter().sum::<f64>() / n;
+    let (mut sxy, mut sxx, mut syy) = (0.0_f64, 0.0_f64, 0.0_f64);
+    for (&xi, &yi) in x.iter().zip(y) {
+        let dx = xi - mean_x;
+        let dy = yi - mean_y;
+        sxy += dx * dy;
+        sxx += dx * dx;
+        syy += dy * dy;
+    }
+    if sxx == 0.0 || syy == 0.0 {
+        return Err(StatsError::invalid_input(format!(
+            "{caller}: correlation is undefined when either variable is constant"
+        )));
+    }
+    Ok((sxy / (sxx * syy).sqrt()).clamp(-1.0, 1.0))
+}
+
+/// Two-sided p-value of `t` under Student-t with `df` degrees of freedom.
+fn t_two_sided_p(t: f64, df: f64) -> f64 {
+    if t.is_infinite() {
+        return 0.0;
+    }
+    regularized_incomplete_beta(df / 2.0, 0.5, df / (t * t + df)).clamp(0.0, 1.0)
+}
+
+/// Pearson product-moment correlation coefficient.
+///
+/// # Errors
+/// Returns an error on length mismatch, fewer than 2 pairs, or when either
+/// variable is constant (zero variance).
+///
+/// # Examples
+/// ```
+/// use rs_stats::prob::correlation::pearson;
+///
+/// let x = [1.0, 2.0, 3.0, 4.0, 5.0];
+/// let y = [2.0, 4.1, 5.9, 8.2, 9.8];
+/// let r = pearson(&x, &y).unwrap();
+/// assert!(r > 0.99);
+/// ```
+pub fn pearson<X, Y>(x: &[X], y: &[Y]) -> StatsResult<f64>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    let (xf, yf) = to_f64_pairs(x, y, "pearson")?;
+    pearson_f64(&xf, &yf, "pearson")
+}
+
+/// Pearson correlation with a two-sided significance test.
+///
+/// `t = r·√((n−2)/(1−r²))` with `n − 2` degrees of freedom (matches
+/// `scipy.stats.pearsonr`). Requires `n ≥ 3`.
+pub fn pearson_test<X, Y>(x: &[X], y: &[Y]) -> StatsResult<CorrelationTest>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    let (xf, yf) = to_f64_pairs(x, y, "pearson_test")?;
+    if xf.len() < 3 {
+        return Err(StatsError::invalid_input(
+            "pearson_test: need at least 3 paired observations for a significance test",
+        ));
+    }
+    let r = pearson_f64(&xf, &yf, "pearson_test")?;
+    let n = xf.len();
+    let df = (n - 2) as f64;
+    let t = if r.abs() >= 1.0 {
+        f64::INFINITY * r.signum()
+    } else {
+        r * (df / (1.0 - r * r)).sqrt()
+    };
+    Ok(CorrelationTest {
+        r,
+        t_statistic: t,
+        p_value: t_two_sided_p(t, df),
+        n,
+    })
+}
+
+/// Spearman rank correlation coefficient `ρ`.
+///
+/// Ranks both variables (average ranks on ties) and computes the Pearson
+/// correlation of the ranks — the standard tie-robust definition used by
+/// `scipy.stats.spearmanr`.
+pub fn spearman<X, Y>(x: &[X], y: &[Y]) -> StatsResult<f64>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    let (xf, yf) = to_f64_pairs(x, y, "spearman")?;
+    let rx = average_ranks(&xf);
+    let ry = average_ranks(&yf);
+    pearson_f64(&rx, &ry, "spearman")
+}
+
+/// Spearman correlation with a two-sided significance test (Student-t
+/// approximation on ρ, as in `scipy.stats.spearmanr`). Requires `n ≥ 3`.
+pub fn spearman_test<X, Y>(x: &[X], y: &[Y]) -> StatsResult<CorrelationTest>
+where
+    X: ToPrimitive,
+    Y: ToPrimitive,
+{
+    let (xf, yf) = to_f64_pairs(x, y, "spearman_test")?;
+    if xf.len() < 3 {
+        return Err(StatsError::invalid_input(
+            "spearman_test: need at least 3 paired observations for a significance test",
+        ));
+    }
+    let rx = average_ranks(&xf);
+    let ry = average_ranks(&yf);
+    let rho = pearson_f64(&rx, &ry, "spearman_test")?;
+    let n = xf.len();
+    let df = (n - 2) as f64;
+    let t = if rho.abs() >= 1.0 {
+        f64::INFINITY * rho.signum()
+    } else {
+        rho * (df / (1.0 - rho * rho)).sqrt()
+    };
+    Ok(CorrelationTest {
+        r: rho,
+        t_statistic: t,
+        p_value: t_two_sided_p(t, df),
+        n,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pearson_perfect() {
+        let x = [1.0, 2.0, 3.0, 4.0];
+        let y = [2.0, 4.0, 6.0, 8.0];
+        assert!((pearson(&x, &y).unwrap() - 1.0).abs() < 1e-12);
+        let y_neg = [8.0, 6.0, 4.0, 2.0];
+        assert!((pearson(&x, &y_neg).unwrap() + 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_pearson_known_value() {
+        // Cross-checked with scipy.stats.pearsonr.
+        let x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+        let y = [2.1, 4.0, 5.9, 8.1, 10.0, 12.2, 13.8];
+        let res = pearson_test(&x, &y).unwrap();
+        assert!((res.r - 0.999534510823262).abs() < 1e-12);
+        // scipy.stats.pearsonr p-value: 8.9767576e-09
+        assert!((res.p_value - 8.976757650992674e-9).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_spearman_monotonic_nonlinear() {
+        // Monotonic but nonlinear: Spearman = 1, Pearson < 1.
+        let x = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let y = [1.0, 8.0, 27.0, 64.0, 125.0];
+        assert!((spearman(&x, &y).unwrap() - 1.0).abs() < 1e-12);
+        assert!(pearson(&x, &y).unwrap() < 1.0);
+    }
+
+    #[test]
+    fn test_spearman_ties() {
+        // Cross-checked with scipy.stats.spearmanr.
+        let x = [1.0, 2.0, 2.0, 3.0, 4.0, 5.0];
+        let y = [1.0, 3.0, 2.0, 3.0, 5.0, 6.0];
+        let rho = spearman(&x, &y).unwrap();
+        assert!((rho - 0.9558823529411764).abs() < 1e-12, "rho = {rho}");
+    }
+
+    #[test]
+    fn test_constant_input_errors() {
+        let x = [1.0, 1.0, 1.0];
+        let y = [1.0, 2.0, 3.0];
+        assert!(pearson(&x, &y).is_err());
+        assert!(pearson(&y, &x).is_err());
+    }
+
+    #[test]
+    fn test_length_mismatch_and_short() {
+        assert!(pearson(&[1.0, 2.0], &[1.0]).is_err());
+        assert!(pearson(&[1.0], &[1.0]).is_err());
+        assert!(pearson_test(&[1.0, 2.0], &[1.0, 2.0]).is_err()); // n < 3
+    }
+}

--- a/src/prob/correlation.rs
+++ b/src/prob/correlation.rs
@@ -45,12 +45,16 @@ where
         .iter()
         .map(|v| v.to_f64())
         .collect::<Option<Vec<f64>>>()
-        .ok_or_else(|| StatsError::conversion_error(format!("{caller}: x not convertible to f64")))?;
+        .ok_or_else(|| {
+            StatsError::conversion_error(format!("{caller}: x not convertible to f64"))
+        })?;
     let yf = y
         .iter()
         .map(|v| v.to_f64())
         .collect::<Option<Vec<f64>>>()
-        .ok_or_else(|| StatsError::conversion_error(format!("{caller}: y not convertible to f64")))?;
+        .ok_or_else(|| {
+            StatsError::conversion_error(format!("{caller}: y not convertible to f64"))
+        })?;
     Ok((xf, yf))
 }
 

--- a/src/prob/describe.rs
+++ b/src/prob/describe.rs
@@ -43,7 +43,14 @@ fn to_sorted_f64<T: ToPrimitive>(data: &[T], caller: &str) -> StatsResult<Vec<f6
         .ok_or_else(|| {
             StatsError::conversion_error(format!("{caller}: data not convertible to f64"))
         })?;
-    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    if xs.iter().any(|v| v.is_nan()) {
+        // A NaN would land at an order-dependent position in the sort and
+        // silently shift every quantile.
+        return Err(StatsError::invalid_input(format!(
+            "{caller}: data contains NaN"
+        )));
+    }
+    xs.sort_by(f64::total_cmp);
     Ok(xs)
 }
 

--- a/src/prob/describe.rs
+++ b/src/prob/describe.rs
@@ -1,0 +1,156 @@
+//! # Descriptive statistics in one call
+//!
+//! [`describe`] summarises a dataset (count, mean, sample std-dev, min,
+//! quartiles, max); [`quantile`] computes any empirical quantile with
+//! linear interpolation (numpy's default, "type 7" in the Hyndman-Fan
+//! taxonomy).
+
+use crate::error::{StatsError, StatsResult};
+use crate::prob::std_dev_sample;
+use num_traits::ToPrimitive;
+
+/// Five-number-plus summary of a dataset.
+#[derive(Debug, Clone, Copy)]
+pub struct Description {
+    /// Number of observations.
+    pub n: usize,
+    /// Arithmetic mean.
+    pub mean: f64,
+    /// **Sample** standard deviation (ddof = 1); `NaN` when `n < 2`.
+    pub std_dev: f64,
+    /// Minimum.
+    pub min: f64,
+    /// First quartile (25th percentile).
+    pub q1: f64,
+    /// Median (50th percentile).
+    pub median: f64,
+    /// Third quartile (75th percentile).
+    pub q3: f64,
+    /// Maximum.
+    pub max: f64,
+}
+
+fn to_sorted_f64<T: ToPrimitive>(data: &[T], caller: &str) -> StatsResult<Vec<f64>> {
+    if data.is_empty() {
+        return Err(StatsError::empty_data(format!(
+            "{caller}: data must not be empty"
+        )));
+    }
+    let mut xs: Vec<f64> = data
+        .iter()
+        .map(|v| v.to_f64())
+        .collect::<Option<_>>()
+        .ok_or_else(|| {
+            StatsError::conversion_error(format!("{caller}: data not convertible to f64"))
+        })?;
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(xs)
+}
+
+/// Empirical quantile of **already sorted** data (linear interpolation).
+fn quantile_sorted(sorted: &[f64], q: f64) -> f64 {
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0];
+    }
+    // numpy default ("linear" / type 7): h = (n−1)·q.
+    let h = (n - 1) as f64 * q;
+    let lo = h.floor() as usize;
+    let hi = h.ceil() as usize;
+    let frac = h - lo as f64;
+    sorted[lo] + frac * (sorted[hi] - sorted[lo])
+}
+
+/// Empirical quantile `q ∈ [0, 1]` of `data`, with linear interpolation
+/// between order statistics (matches `numpy.quantile`'s default).
+///
+/// # Errors
+/// Returns an error on empty data or `q` outside `[0, 1]`.
+///
+/// # Examples
+/// ```
+/// use rs_stats::prob::quantile;
+///
+/// let data = [2.0, 7.0, 4.0, 1.0, 9.0, 3.0, 8.0, 5.0, 6.0, 10.0];
+/// assert!((quantile(&data, 0.5).unwrap() - 5.5).abs() < 1e-12);
+/// assert!((quantile(&data, 0.9).unwrap() - 9.1).abs() < 1e-12);
+/// ```
+pub fn quantile<T: ToPrimitive>(data: &[T], q: f64) -> StatsResult<f64> {
+    if !(0.0..=1.0).contains(&q) {
+        return Err(StatsError::invalid_parameter(format!(
+            "quantile: q must be in [0, 1], got {q}"
+        )));
+    }
+    let sorted = to_sorted_f64(data, "quantile")?;
+    Ok(quantile_sorted(&sorted, q))
+}
+
+/// One-call descriptive summary: count, mean, sample std-dev, min,
+/// quartiles and max.
+///
+/// # Examples
+/// ```
+/// use rs_stats::prob::describe;
+///
+/// let data = [12.1, 14.3, 13.8, 15.2, 14.9, 13.1, 14.0, 16.4];
+/// let d = describe(&data).unwrap();
+/// assert_eq!(d.n, 8);
+/// assert!(d.min <= d.q1 && d.q1 <= d.median && d.median <= d.q3 && d.q3 <= d.max);
+/// ```
+pub fn describe<T: ToPrimitive + std::fmt::Debug>(data: &[T]) -> StatsResult<Description> {
+    let sorted = to_sorted_f64(data, "describe")?;
+    let n = sorted.len();
+    let mean = sorted.iter().sum::<f64>() / n as f64;
+    let std_dev = if n >= 2 {
+        std_dev_sample(&sorted)?
+    } else {
+        f64::NAN
+    };
+    Ok(Description {
+        n,
+        mean,
+        std_dev,
+        min: sorted[0],
+        q1: quantile_sorted(&sorted, 0.25),
+        median: quantile_sorted(&sorted, 0.5),
+        q3: quantile_sorted(&sorted, 0.75),
+        max: sorted[n - 1],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quantile_matches_numpy() {
+        // Reference: numpy.quantile (linear interpolation).
+        let data = [2.0, 7.0, 4.0, 1.0, 9.0, 3.0, 8.0, 5.0, 6.0, 10.0];
+        assert!((quantile(&data, 0.25).unwrap() - 3.25).abs() < 1e-12);
+        assert!((quantile(&data, 0.5).unwrap() - 5.5).abs() < 1e-12);
+        assert!((quantile(&data, 0.9).unwrap() - 9.1).abs() < 1e-12);
+        assert_eq!(quantile(&data, 0.0).unwrap(), 1.0);
+        assert_eq!(quantile(&data, 1.0).unwrap(), 10.0);
+    }
+
+    #[test]
+    fn test_describe_basic() {
+        let data = [1, 2, 3, 4, 5];
+        let d = describe(&data).unwrap();
+        assert_eq!(d.n, 5);
+        assert!((d.mean - 3.0).abs() < 1e-12);
+        assert!((d.std_dev - 2.5_f64.sqrt()).abs() < 1e-12);
+        assert_eq!(d.min, 1.0);
+        assert_eq!(d.median, 3.0);
+        assert_eq!(d.max, 5.0);
+    }
+
+    #[test]
+    fn test_describe_errors_and_edge() {
+        assert!(describe::<f64>(&[]).is_err());
+        assert!(quantile(&[1.0], 1.5).is_err());
+        let d = describe(&[42.0]).unwrap();
+        assert_eq!(d.median, 42.0);
+        assert!(d.std_dev.is_nan());
+    }
+}

--- a/src/prob/erf.rs
+++ b/src/prob/erf.rs
@@ -34,9 +34,11 @@ const THRESH: f64 = 0.46875;
 /// erfc underflows to 0 beyond this point (exp(−x²) < DBL_MIN).
 const XBIG: f64 = 26.543;
 /// 1/√π.
+#[allow(clippy::excessive_precision)]
 const SQRPI: f64 = 5.641_895_835_477_562_9e-1;
 
 /// erf numerator/denominator, |x| ≤ 0.46875.
+#[allow(clippy::excessive_precision)]
 const A: [f64; 5] = [
     3.161_123_743_870_565_6e0,
     1.138_641_541_510_501_56e2,
@@ -44,6 +46,7 @@ const A: [f64; 5] = [
     3.209_377_589_138_469_47e3,
     1.857_777_061_846_031_53e-1,
 ];
+#[allow(clippy::excessive_precision)]
 const B: [f64; 4] = [
     2.360_129_095_234_412_09e1,
     2.440_246_379_344_441_73e2,
@@ -51,6 +54,7 @@ const B: [f64; 4] = [
     2.844_236_833_439_170_62e3,
 ];
 /// erfc·exp(x²) numerator/denominator, 0.46875 < x ≤ 4.
+#[allow(clippy::excessive_precision)]
 const C: [f64; 9] = [
     5.641_884_969_886_700_89e-1,
     8.883_149_794_388_375_94e0,
@@ -62,6 +66,7 @@ const C: [f64; 9] = [
     1.230_339_354_797_997_25e3,
     2.153_115_354_744_038_46e-8,
 ];
+#[allow(clippy::excessive_precision)]
 const D: [f64; 8] = [
     1.574_492_611_070_983_47e1,
     1.176_939_508_913_124_99e2,
@@ -73,6 +78,7 @@ const D: [f64; 8] = [
     1.230_339_354_803_749_42e3,
 ];
 /// erfc·x·exp(x²) − 1/√π correction, x > 4.
+#[allow(clippy::excessive_precision)]
 const P: [f64; 6] = [
     3.053_266_349_612_323_44e-1,
     3.603_448_999_498_044_39e-1,
@@ -81,6 +87,7 @@ const P: [f64; 6] = [
     6.587_491_615_298_378_03e-4,
     1.631_538_713_730_209_78e-2,
 ];
+#[allow(clippy::excessive_precision)]
 const Q: [f64; 5] = [
     2.568_520_192_289_822_42e0,
     1.872_952_849_923_460_47e0,

--- a/src/prob/erf.rs
+++ b/src/prob/erf.rs
@@ -15,15 +15,141 @@
 //! - erf(-∞) = -1
 //!
 //! ## Implementation Details
-//! Computed via the regularised lower incomplete gamma function:
-//!   erf(x) = sign(x) · P(1/2, x²)
-//! This delegates to [`crate::utils::special_functions::regularized_incomplete_gamma`]
-//! and is accurate to ~1e-12 across the real line — substantially better
-//! than the previous Abramowitz-Stegun 7.1.26 approximation (max error 1.5e-7).
+//! Computed with W. J. Cody's rational Chebyshev approximations (the
+//! CALERF algorithm, 1969/1990 — the same scheme used by glibc and
+//! Fortran SPECFUN): three regions, each a small fixed-degree rational,
+//! accurate to ~1 ulp across the real line. Replaces the previous
+//! delegation to the *iterative* regularized incomplete gamma (up to 300
+//! series/continued-fraction steps per call) — same accuracy, an order
+//! of magnitude faster on the `Normal::cdf` hot path.
 
 use crate::error::{StatsError, StatsResult};
-use crate::utils::special_functions::regularized_incomplete_gamma;
 use num_traits::ToPrimitive;
+
+// ── Cody / CALERF rational approximations ─────────────────────────────────────
+
+/// Region boundary: below this |x| use the erf rational, above it the
+/// erfc rationals.
+const THRESH: f64 = 0.46875;
+/// erfc underflows to 0 beyond this point (exp(−x²) < DBL_MIN).
+const XBIG: f64 = 26.543;
+/// 1/√π.
+const SQRPI: f64 = 5.641_895_835_477_562_9e-1;
+
+/// erf numerator/denominator, |x| ≤ 0.46875.
+const A: [f64; 5] = [
+    3.161_123_743_870_565_6e0,
+    1.138_641_541_510_501_56e2,
+    3.774_852_376_853_020_2e2,
+    3.209_377_589_138_469_47e3,
+    1.857_777_061_846_031_53e-1,
+];
+const B: [f64; 4] = [
+    2.360_129_095_234_412_09e1,
+    2.440_246_379_344_441_73e2,
+    1.282_616_526_077_372_28e3,
+    2.844_236_833_439_170_62e3,
+];
+/// erfc·exp(x²) numerator/denominator, 0.46875 < x ≤ 4.
+const C: [f64; 9] = [
+    5.641_884_969_886_700_89e-1,
+    8.883_149_794_388_375_94e0,
+    6.611_919_063_714_162_95e1,
+    2.986_351_381_974_001_31e2,
+    8.819_522_212_417_690_9e2,
+    1.712_047_612_634_070_58e3,
+    2.051_078_377_826_071_47e3,
+    1.230_339_354_797_997_25e3,
+    2.153_115_354_744_038_46e-8,
+];
+const D: [f64; 8] = [
+    1.574_492_611_070_983_47e1,
+    1.176_939_508_913_124_99e2,
+    5.371_811_018_620_098_58e2,
+    1.621_389_574_566_690_19e3,
+    3.290_799_235_733_459_63e3,
+    4.362_619_090_143_247_16e3,
+    3.439_367_674_143_721_64e3,
+    1.230_339_354_803_749_42e3,
+];
+/// erfc·x·exp(x²) − 1/√π correction, x > 4.
+const P: [f64; 6] = [
+    3.053_266_349_612_323_44e-1,
+    3.603_448_999_498_044_39e-1,
+    1.257_817_261_112_292_46e-1,
+    1.608_378_514_874_227_66e-2,
+    6.587_491_615_298_378_03e-4,
+    1.631_538_713_730_209_78e-2,
+];
+const Q: [f64; 5] = [
+    2.568_520_192_289_822_42e0,
+    1.872_952_849_923_460_47e0,
+    5.279_051_029_514_284_12e-1,
+    6.051_834_131_244_131_91e-2,
+    2.335_204_976_268_691_85e-3,
+];
+
+/// Region 1: erf(x) for |x| ≤ 0.46875 (rational in x²).
+fn erf_small(x: f64) -> f64 {
+    let z = x * x;
+    let mut xnum = A[4] * z;
+    let mut xden = z;
+    for i in 0..3 {
+        xnum = (xnum + A[i]) * z;
+        xden = (xden + B[i]) * z;
+    }
+    x * (xnum + A[3]) / (xden + B[3])
+}
+
+/// Regions 2–3: erfc(y) for y > 0.46875.
+fn erfc_large(y: f64) -> f64 {
+    let r = if y <= 4.0 {
+        let mut xnum = C[8] * y;
+        let mut xden = y;
+        for i in 0..7 {
+            xnum = (xnum + C[i]) * y;
+            xden = (xden + D[i]) * y;
+        }
+        (xnum + C[7]) / (xden + D[7])
+    } else {
+        if y >= XBIG {
+            return 0.0;
+        }
+        let z = 1.0 / (y * y);
+        let mut xnum = P[5] * z;
+        let mut xden = z;
+        for i in 0..4 {
+            xnum = (xnum + P[i]) * z;
+            xden = (xden + Q[i]) * z;
+        }
+        (SQRPI - z * (xnum + P[4]) / (xden + Q[4])) / y
+    };
+    // exp(−y²) via the split y² = ysq² + del with ysq on a 1/16 grid:
+    // ysq·ysq is exact in f64, so the product of the two exps keeps
+    // full relative precision (a direct exp(−y²) loses ~y²·ulp).
+    let ysq = (y * 16.0).trunc() / 16.0;
+    let del = (y - ysq) * (y + ysq);
+    (-ysq * ysq).exp() * (-del).exp() * r
+}
+
+/// erf via Cody's rationals; ~1 ulp over the real line.
+pub(crate) fn erf_cody(x: f64) -> f64 {
+    if x.abs() <= THRESH {
+        return erf_small(x);
+    }
+    let e = erfc_large(x.abs());
+    if x >= 0.0 { 1.0 - e } else { e - 1.0 }
+}
+
+/// erfc via Cody's rationals — full *relative* precision in the upper
+/// tail (down to ~1e-308), where `1 − erf` collapses.
+pub(crate) fn erfc_cody(x: f64) -> f64 {
+    if x.abs() <= THRESH {
+        return 1.0 - erf_small(x);
+    }
+    let e = erfc_large(x.abs());
+    if x >= 0.0 { e } else { 2.0 - e }
+}
 
 /// Calculate the error function (erf) of a value
 ///
@@ -65,9 +191,7 @@ where
     if x.is_infinite() {
         return Ok(if x > 0.0 { 1.0 } else { -1.0 });
     }
-    let sign = x.signum();
-    // erf(x) = sign(x) · P(1/2, x²) via the canonical incomplete gamma.
-    Ok(sign * regularized_incomplete_gamma(0.5, x * x))
+    Ok(erf_cody(x))
 }
 
 #[cfg(test)]

--- a/src/prob/erfc.rs
+++ b/src/prob/erfc.rs
@@ -20,6 +20,7 @@
 
 use crate::error::{StatsError, StatsResult};
 use crate::prob::erf;
+use crate::utils::special_functions::regularized_incomplete_gamma_upper;
 use num_traits::ToPrimitive;
 
 /// Calculate the complementary error function (erfc) of a value
@@ -53,6 +54,12 @@ where
     let x_64 = x.to_f64().ok_or_else(|| StatsError::ConversionError {
         message: "prob::erfc: Failed to convert x to f64".to_string(),
     })?;
+    // In the upper tail erfc(x) is tiny; `1 − erf(x)` destroys its relative
+    // precision (and rounds to 0 for x ≳ 6). Compute Q(1/2, x²) directly
+    // instead. Below the threshold erfc is O(1) and `1 − erf` is exact enough.
+    if x_64 > 0.5 {
+        return Ok(regularized_incomplete_gamma_upper(0.5, x_64 * x_64));
+    }
     Ok(1.0 - erf(x_64)?)
 }
 

--- a/src/prob/erfc.rs
+++ b/src/prob/erfc.rs
@@ -19,8 +19,6 @@
 //! P(X > x) = 0.5 * erfc(x/√2)
 
 use crate::error::{StatsError, StatsResult};
-use crate::prob::erf;
-use crate::utils::special_functions::regularized_incomplete_gamma_upper;
 use num_traits::ToPrimitive;
 
 /// Calculate the complementary error function (erfc) of a value
@@ -54,13 +52,15 @@ where
     let x_64 = x.to_f64().ok_or_else(|| StatsError::ConversionError {
         message: "prob::erfc: Failed to convert x to f64".to_string(),
     })?;
-    // In the upper tail erfc(x) is tiny; `1 − erf(x)` destroys its relative
-    // precision (and rounds to 0 for x ≳ 6). Compute Q(1/2, x²) directly
-    // instead. Below the threshold erfc is O(1) and `1 − erf` is exact enough.
-    if x_64 > 0.5 {
-        return Ok(regularized_incomplete_gamma_upper(0.5, x_64 * x_64));
+    if x_64.is_nan() {
+        return Ok(f64::NAN);
     }
-    Ok(1.0 - erf(x_64)?)
+    if x_64.is_infinite() {
+        return Ok(if x_64 > 0.0 { 0.0 } else { 2.0 });
+    }
+    // Cody's rational approximations: full relative precision in the upper
+    // tail (down to ~1e-308), where `1 − erf(x)` rounds to 0.
+    Ok(crate::prob::erf::erfc_cody(x_64))
 }
 
 #[cfg(test)]

--- a/src/prob/mod.rs
+++ b/src/prob/mod.rs
@@ -6,6 +6,7 @@
 //! [`crate::distributions::normal_distribution::Normal`] directly.
 
 pub mod average;
+pub mod correlation;
 pub mod erf;
 pub mod erfc;
 pub mod std_dev;
@@ -15,6 +16,7 @@ pub mod welford;
 pub mod z_score;
 
 pub use self::average::average;
+pub use self::correlation::{CorrelationTest, pearson, pearson_test, spearman, spearman_test};
 pub use self::erf::erf;
 pub use self::erfc::erfc;
 pub use self::std_dev::{std_dev, std_dev_population, std_dev_sample};

--- a/src/prob/mod.rs
+++ b/src/prob/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod average;
 pub mod correlation;
+pub mod describe;
 pub mod erf;
 pub mod erfc;
 pub mod std_dev;
@@ -17,6 +18,7 @@ pub mod z_score;
 
 pub use self::average::average;
 pub use self::correlation::{CorrelationTest, pearson, pearson_test, spearman, spearman_test};
+pub use self::describe::{Description, describe, quantile};
 pub use self::erf::erf;
 pub use self::erfc::erfc;
 pub use self::std_dev::{std_dev, std_dev_population, std_dev_sample};

--- a/src/prob/mod.rs
+++ b/src/prob/mod.rs
@@ -18,7 +18,7 @@ pub use self::average::average;
 pub use self::erf::erf;
 pub use self::erfc::erfc;
 pub use self::std_dev::{std_dev, std_dev_population, std_dev_sample};
-pub use self::std_err::std_err;
+pub use self::std_err::{std_err, std_err_population};
 pub use self::variance::{variance, variance_population, variance_sample};
 pub use self::welford::{Welford, WelfordCovariance, WelfordVector};
 pub use self::z_score::z_score;

--- a/src/prob/std_err.rs
+++ b/src/prob/std_err.rs
@@ -64,7 +64,7 @@ where
 /// Standard error of the mean using the **population** standard deviation
 /// (ddof = 0).
 ///
-/// This was the (undocumented) behaviour of [`std_err`] before v3.1; prefer
+/// This was the (undocumented) behaviour of [`std_err`] before v4.0; prefer
 /// [`std_err`] unless you specifically have the full population.
 #[inline]
 pub fn std_err_population<T>(data: &[T]) -> StatsResult<f64>

--- a/src/prob/std_err.rs
+++ b/src/prob/std_err.rs
@@ -18,13 +18,14 @@
 //! - Used in confidence intervals and hypothesis testing
 
 use crate::error::StatsResult;
-use crate::prob::std_dev;
+use crate::prob::{std_dev_population, std_dev_sample};
 use num_traits::ToPrimitive;
 
-/// Calculate the standard error of a dataset
+/// Calculate the standard error of the mean (SEM) of a dataset.
 ///
-/// The standard error quantifies the uncertainty in the sample mean
-/// as an estimate of the population mean.
+/// Uses the **sample** standard deviation (ddof = 1), the standard SEM
+/// convention (matches `scipy.stats.sem`). The population variant is
+/// available as [`std_err_population`].
 ///
 /// # Arguments
 /// * `data` - A slice of numeric values implementing `ToPrimitive`
@@ -34,16 +35,18 @@ use num_traits::ToPrimitive;
 ///
 /// # Errors
 /// Returns `StatsError::EmptyData` if the input slice is empty.
+/// Returns `StatsError::InvalidInput` if the slice has fewer than 2 elements
+/// (the sample standard deviation needs n ≥ 2).
 /// Returns `StatsError::ConversionError` if any value cannot be converted to f64.
 ///
 /// # Examples
 /// ```
 /// use rs_stats::prob::std_err;
 ///
-/// // Calculate standard error for a dataset
+/// // Calculate standard error for a dataset (sample convention, like scipy.stats.sem)
 /// let data = [1.0, 2.0, 3.0, 4.0, 5.0];
 /// let se = std_err(&data)?;
-/// assert!((se - 0.632455532).abs() < 1e-9);
+/// assert!((se - 0.7071067811865476).abs() < 1e-9);
 ///
 /// // Handle empty input
 /// let empty_data: &[f64] = &[];
@@ -55,7 +58,20 @@ pub fn std_err<T>(data: &[T]) -> StatsResult<f64>
 where
     T: ToPrimitive + std::fmt::Debug,
 {
-    std_dev(data).map(|std| std / (data.len() as f64).sqrt())
+    std_dev_sample(data).map(|std| std / (data.len() as f64).sqrt())
+}
+
+/// Standard error of the mean using the **population** standard deviation
+/// (ddof = 0).
+///
+/// This was the (undocumented) behaviour of [`std_err`] before v3.1; prefer
+/// [`std_err`] unless you specifically have the full population.
+#[inline]
+pub fn std_err_population<T>(data: &[T]) -> StatsResult<f64>
+where
+    T: ToPrimitive + std::fmt::Debug,
+{
+    std_dev_population(data).map(|std| std / (data.len() as f64).sqrt())
 }
 
 #[cfg(test)]
@@ -67,41 +83,44 @@ mod tests {
     #[test]
     fn test_std_err_integers() {
         // Dataset: [1, 2, 3, 4, 5]
-        // Standard deviation of [1, 2, 3, 4, 5] is 1.414213562 (approx)
-        // Standard error should be std_dev / sqrt(n) = 1.414213562 / sqrt(5) = 0.632455532 (approx)
+        // Sample std-dev (ddof=1) = sqrt(2.5) ≈ 1.5811388
+        // SEM = 1.5811388 / sqrt(5) ≈ 0.7071068 (matches scipy.stats.sem)
         let data = vec![1, 2, 3, 4, 5];
         let result = std_err(&data).unwrap();
-        let expected = 0.632455532; // Calculated value of the standard error
+        let expected = std::f64::consts::FRAC_1_SQRT_2;
         assert!(
             (result - expected).abs() < EPSILON,
-            "Standard error should be approximately 0.632455532"
+            "Standard error should be approximately 0.7071068"
         );
     }
 
     #[test]
     fn test_std_err_floats() {
-        // Dataset: [1.0, 2.0, 3.0, 4.0, 5.0]
-        // Standard deviation of [1.0, 2.0, 3.0, 4.0, 5.0] is the same as for integers
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let result = std_err(&data).unwrap();
-        let expected = 0.632455532;
+        let expected = std::f64::consts::FRAC_1_SQRT_2;
         assert!(
             (result - expected).abs() < EPSILON,
-            "Standard error for floats should be approximately 0.632455532"
+            "Standard error for floats should be approximately 0.7071068"
         );
     }
 
     #[test]
+    fn test_std_err_population_variant() {
+        // Population convention: pop std-dev = sqrt(2) ≈ 1.4142136,
+        // SEM_pop = 1.4142136 / sqrt(5) ≈ 0.6324555.
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let result = std_err_population(&data).unwrap();
+        let expected = 0.6324555320336759;
+        assert!((result - expected).abs() < EPSILON);
+    }
+
+    #[test]
     fn test_std_err_single_element() {
-        // Dataset with only one element: [5]
-        // Standard deviation is 0, and thus standard error should also be 0
+        // The sample standard deviation is undefined for n = 1 —
+        // a single point carries no information about spread.
         let data = vec![5];
-        let result = std_err(&data).unwrap();
-        let expected = 0.0;
-        assert_eq!(
-            result, expected,
-            "Standard error for a single element should be 0.0"
-        );
+        assert!(std_err(&data).is_err());
     }
 
     #[test]

--- a/src/prob/welford.rs
+++ b/src/prob/welford.rs
@@ -216,7 +216,7 @@ impl Welford {
 
     /// Population variance `M2 / n`. Returns `0.0` for an empty estimator.
     #[deprecated(
-        since = "3.1.0",
+        since = "4.0.0",
         note = "renamed to `variance_population` for symmetry with `prob::variance_population`"
     )]
     #[inline]

--- a/src/prob/welford.rs
+++ b/src/prob/welford.rs
@@ -174,7 +174,13 @@ impl Welford {
         self.mean
     }
 
-    /// Sample variance `M2 / (n-1)`.
+    /// **Sample** variance `M2 / (n-1)` (ddof = 1).
+    ///
+    /// ⚠️ Convention mismatch with the free function
+    /// [`prob::variance`](crate::prob::variance), which is the **population**
+    /// estimator (ddof = 0). Prefer the explicit names
+    /// [`variance_sample`](Self::variance_sample) /
+    /// [`variance_population`](Self::variance_population) in new code.
     ///
     /// # Errors
     /// Returns [`StatsError::EmptyData`] if `count() < 2` — sample variance
@@ -188,14 +194,34 @@ impl Welford {
         Ok(self.m2 / (self.n - 1) as f64)
     }
 
-    /// Population variance `M2 / n`. Returns `0.0` for an empty estimator.
+    /// Sample variance `M2 / (n-1)` — explicit alias of
+    /// [`variance`](Self::variance), mirroring
+    /// [`prob::variance_sample`](crate::prob::variance_sample).
     #[inline]
-    pub fn population_variance(&self) -> f64 {
+    pub fn variance_sample(&self) -> StatsResult<f64> {
+        self.variance()
+    }
+
+    /// Population variance `M2 / n` (ddof = 0), mirroring
+    /// [`prob::variance_population`](crate::prob::variance_population).
+    /// Returns `0.0` for an empty estimator.
+    #[inline]
+    pub fn variance_population(&self) -> f64 {
         if self.n == 0 {
             0.0
         } else {
             self.m2 / self.n as f64
         }
+    }
+
+    /// Population variance `M2 / n`. Returns `0.0` for an empty estimator.
+    #[deprecated(
+        since = "3.1.0",
+        note = "renamed to `variance_population` for symmetry with `prob::variance_population`"
+    )]
+    #[inline]
+    pub fn population_variance(&self) -> f64 {
+        self.variance_population()
     }
 
     /// Sample standard deviation.
@@ -679,7 +705,7 @@ mod tests {
         for x in [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0] {
             w.push(x);
         }
-        let pop_var = w.population_variance();
+        let pop_var = w.variance_population();
         let samp_var = w.variance().unwrap();
         // sample = pop * n / (n-1)
         assert!(approx(samp_var, pop_var * 8.0 / 7.0, 1e-12));

--- a/src/prob/z_score.rs
+++ b/src/prob/z_score.rs
@@ -32,7 +32,13 @@ use num_traits::ToPrimitive;
 /// * `stddev` - The standard deviation (σ) of the distribution
 ///
 /// # Returns
-/// The z-score of the value. Returns infinity if stddev is 0.
+/// The z-score of the value.
+///
+/// # Errors
+/// Returns `StatsError::InvalidInput` if `stddev` is zero, negative, or not
+/// finite: a z-score is undefined without positive dispersion (the old
+/// behaviour silently returned `+∞`, even for the 0/0 case `x == avg`, and
+/// accepted a negative σ that flipped the sign of every score).
 ///
 /// # Examples
 /// ```
@@ -46,17 +52,18 @@ use num_traits::ToPrimitive;
 /// let z = z_score(55.0, 70.0, 10.0).unwrap();
 /// assert!((z - (-1.5)).abs() < 1e-10);
 ///
-/// // Handle zero standard deviation case
-/// let z = z_score(70.0, 70.0, 0.0).unwrap();
-/// assert!(z.is_infinite());
+/// // Zero standard deviation is an error, not infinity
+/// assert!(z_score(70.0, 70.0, 0.0).is_err());
 /// ```
 #[inline]
 pub fn z_score<T>(x: T, avg: f64, stddev: f64) -> StatsResult<f64>
 where
     T: ToPrimitive,
 {
-    if stddev == 0.0 {
-        return Ok(f64::INFINITY);
+    if stddev <= 0.0 || !stddev.is_finite() {
+        return Err(StatsError::invalid_input(format!(
+            "prob::z_score: standard deviation must be positive and finite, got {stddev}"
+        )));
     }
 
     let x_64 = x.to_f64().ok_or_else(|| StatsError::ConversionError {
@@ -112,15 +119,15 @@ mod tests {
     }
 
     #[test]
-    fn test_z_score_zero_stddev() {
-        let x = 3.0;
-        let avg = 3.0;
-        let stddev = 0.0;
-        let result = z_score(x, avg, stddev).unwrap();
-        assert!(
-            result.is_infinite(),
-            "Z-score should be infinite when stddev is 0"
-        );
+    fn test_z_score_invalid_stddev() {
+        // σ = 0 (including the 0/0 case x == avg), σ < 0 and non-finite σ
+        // are all undefined — typed errors, not ±∞.
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                z_score(3.0, 3.0, bad).is_err(),
+                "z_score should reject stddev = {bad}"
+            );
+        }
     }
 
     #[test]

--- a/src/regression/decision_tree.rs
+++ b/src/regression/decision_tree.rs
@@ -535,7 +535,7 @@ where
 
     /// Sum of |y − median(ys)| — the MAE numerator. The median (not the
     /// mean) is the MAE minimiser; centring on the mean, as done before
-    /// v3.1, computed a different quantity ("mean absolute deviation
+    /// v4.0, computed a different quantity ("mean absolute deviation
     /// around the mean") under the MAE name.
     fn sum_abs_dev_median(ys: &[F], scratch: &mut Vec<F>) -> F {
         scratch.clear();
@@ -739,7 +739,7 @@ where
     ///
     /// Returns one entry per input feature seen at fit time (unused features
     /// get 0). Deriving the count from the first split node — as done before
-    /// v3.1 — panicked whenever a deeper node split on a higher feature index.
+    /// v4.0 — panicked whenever a deeper node split on a higher feature index.
     pub fn feature_importances(&self) -> Vec<F> {
         if self.nodes.is_empty() {
             return Vec::new();
@@ -1484,7 +1484,7 @@ mod tests {
 
     #[test]
     fn test_f64_regression_target_compiles_and_fits() {
-        // The headline of the v3.1 tree refactor: f64 targets no longer
+        // The headline of the v4.0 tree refactor: f64 targets no longer
         // need a wrapper type (the old `Eq + Hash` bound made
         // `DecisionTree<f64, f64>` a compile error).
         let mut tree =
@@ -1550,7 +1550,7 @@ mod tests {
     #[test]
     fn test_feature_importances_deep_split_on_higher_feature() {
         // Regression test: the root splits on feature 0, a deeper node
-        // splits on feature 1. Pre-v3.1 the feature count was derived from
+        // splits on feature 1. Pre-v4.0 the feature count was derived from
         // the FIRST split node (→ len 1) and indexing feature 1 panicked.
         let mut tree =
             DecisionTree::<i32, f64>::new(TreeType::Classification, SplitCriterion::Gini, 5, 2, 1);

--- a/src/regression/decision_tree.rs
+++ b/src/regression/decision_tree.rs
@@ -125,6 +125,8 @@ where
     min_samples_leaf: usize,
     /// Nodes in the tree
     nodes: Vec<Node<T, F>>,
+    /// Number of input features seen at fit time (0 before fitting)
+    n_features: usize,
 }
 
 impl<T, F> DecisionTree<T, F>
@@ -151,6 +153,7 @@ where
             min_samples_split,
             min_samples_leaf,
             nodes: Vec::new(),
+            n_features: 0,
         }
     }
 
@@ -195,6 +198,7 @@ where
 
         // Reset the tree
         self.nodes = Vec::new();
+        self.n_features = n_features;
 
         // Create sample indices (initially all samples)
         let indices: Vec<usize> = (0..features.len()).collect();
@@ -679,21 +683,17 @@ where
         }
     }
 
-    /// Get the importance of each feature
+    /// Get the importance of each feature.
+    ///
+    /// Returns one entry per input feature seen at fit time (unused features
+    /// get 0). Deriving the count from the first split node — as done before
+    /// v3.1 — panicked whenever a deeper node split on a higher feature index.
     pub fn feature_importances(&self) -> Vec<F> {
         if self.nodes.is_empty() {
             return Vec::new();
         }
 
-        // Count the number of features from the first non-leaf node
-        let n_features = self
-            .nodes
-            .iter()
-            .find(|node| !node.is_leaf())
-            .and_then(|node| node.feature_idx)
-            .map(|idx| idx + 1)
-            .unwrap_or(0);
-
+        let n_features = self.n_features;
         if n_features == 0 {
             return Vec::new();
         }
@@ -1428,5 +1428,33 @@ mod tests {
             result.unwrap_err(),
             StatsError::InvalidInput { .. }
         ));
+    }
+
+    #[test]
+    fn test_feature_importances_deep_split_on_higher_feature() {
+        // Regression test: the root splits on feature 0, a deeper node
+        // splits on feature 1. Pre-v3.1 the feature count was derived from
+        // the FIRST split node (→ len 1) and indexing feature 1 panicked.
+        let mut tree =
+            DecisionTree::<i32, f64>::new(TreeType::Classification, SplitCriterion::Gini, 5, 2, 1);
+        // f0 cleanly separates class 2; inside f0 ≤ 3, f1 separates 0 vs 1.
+        let features = vec![
+            vec![0, 0],
+            vec![1, 10],
+            vec![2, 0],
+            vec![3, 10],
+            vec![10, 0],
+            vec![11, 10],
+            vec![12, 0],
+            vec![13, 10],
+        ];
+        let target = vec![0, 1, 0, 1, 2, 2, 2, 2];
+        tree.fit(&features, &target).unwrap();
+
+        let importances = tree.feature_importances();
+        assert_eq!(importances.len(), 2, "one entry per input feature");
+        let total: f64 = importances.iter().sum();
+        assert!((total - 1.0).abs() < 1e-12, "importances sum to 1");
+        assert!(importances.iter().all(|&v| v > 0.0), "both features used");
     }
 }

--- a/src/regression/decision_tree.rs
+++ b/src/regression/decision_tree.rs
@@ -3,9 +3,7 @@ use num_traits::cast::AsPrimitive;
 use num_traits::{Float, FromPrimitive, NumCast, ToPrimitive};
 use rayon::prelude::*;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::fmt::{self, Debug};
-use std::hash::Hash;
 
 /// Types of decision trees that can be created
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -42,8 +40,10 @@ where
     threshold: Option<T>,
     /// Value to return if this is a leaf node
     value: Option<T>,
-    /// Class distribution for classification trees
-    class_distribution: Option<HashMap<T, usize>>,
+    /// Class distribution for classification trees, sorted by class.
+    /// A sorted `Vec` instead of a `HashMap` so that `T` only needs
+    /// `PartialOrd` — which lets `DecisionTree<f64, f64>` compile.
+    class_distribution: Option<Vec<(T, usize)>>,
     /// Left child node index
     left: Option<usize>,
     /// Right child node index
@@ -54,7 +54,7 @@ where
 
 impl<T, F> Node<T, F>
 where
-    T: Clone + PartialOrd + Eq + Hash + Debug + ToPrimitive,
+    T: Clone + PartialOrd + Debug + ToPrimitive,
     F: Float,
 {
     /// Create a new internal node with a split condition
@@ -84,7 +84,7 @@ where
     }
 
     /// Create a new leaf node for classification
-    fn new_leaf_classification(value: T, class_distribution: HashMap<T, usize>) -> Self {
+    fn new_leaf_classification(value: T, class_distribution: Vec<(T, usize)>) -> Self {
         Node {
             feature_idx: None,
             threshold: None,
@@ -131,7 +131,7 @@ where
 
 impl<T, F> DecisionTree<T, F>
 where
-    T: Clone + PartialOrd + Eq + Hash + Send + Sync + NumCast + ToPrimitive + Debug,
+    T: Clone + PartialOrd + Send + Sync + NumCast + ToPrimitive + Debug,
     F: Float + Send + Sync + NumCast + FromPrimitive + 'static,
     f64: AsPrimitive<F>,
     usize: AsPrimitive<F>,
@@ -226,8 +226,12 @@ where
         {
             let node_idx = self.nodes.len();
             if self.tree_type == TreeType::Regression {
-                // For regression, use the mean value
-                let value = self.calculate_mean(target, indices)?;
+                // MAE-optimal prediction is the median; MSE-optimal is the mean.
+                let value = if self.criterion == SplitCriterion::Mae {
+                    self.calculate_median(target, indices)?
+                } else {
+                    self.calculate_mean(target, indices)?
+                };
                 self.nodes.push(Node::new_leaf_regression(value));
             } else {
                 // For classification, use the most common class
@@ -246,7 +250,11 @@ where
         if left_indices.is_empty() || right_indices.is_empty() {
             let node_idx = self.nodes.len();
             if self.tree_type == TreeType::Regression {
-                let value = self.calculate_mean(target, indices)?;
+                let value = if self.criterion == SplitCriterion::Mae {
+                    self.calculate_median(target, indices)?
+                } else {
+                    self.calculate_mean(target, indices)?
+                };
                 self.nodes.push(Node::new_leaf_regression(value));
             } else {
                 let (value, class_counts) = self.calculate_class_distribution(target, indices);
@@ -281,13 +289,16 @@ where
 
     /// Find the best split for the given samples.
     ///
-    /// Per (node, feature) cost is dominated by one O(n log n) sort plus
-    /// one O(n) walk of candidate thresholds. The previous implementation
-    /// rebuilt `left_indices` / `right_indices` as fresh `Vec`s for every
-    /// candidate threshold (an inner loop of size O(unique values)),
-    /// which produced O(features × thresholds) per-node allocations. Now
-    /// we sort once and use prefix / suffix slices of the sorted index
-    /// vector — only the **best** split's index vectors are materialised.
+    /// Per (node, feature): one O(n log n) sort of contiguous
+    /// `(value, position)` pairs, then a **single incremental sweep** of
+    /// the candidate thresholds — running sums for MSE, running class
+    /// counts for Gini/entropy — so each candidate costs O(1) (or
+    /// O(n_classes)) instead of a full re-scan of both sides. The previous
+    /// implementation re-walked left AND right per candidate (O(n²) per
+    /// feature) and allocated two HashMaps per candidate in
+    /// classification. MAE is the exception: its minimiser is the median,
+    /// which can't be maintained in O(1) — it re-selects the median per
+    /// candidate and is documented as the slower criterion.
     fn find_best_split<D>(
         &self,
         features: &[Vec<D>],
@@ -298,6 +309,7 @@ where
         D: Clone + Copy + PartialOrd + NumCast + ToPrimitive + AsPrimitive<F> + Send + Sync,
     {
         let n_features = features[0].len();
+        let n_samples = indices.len();
 
         let mut best_impurity = F::infinity();
         let mut best_feature = 0;
@@ -305,72 +317,164 @@ where
         let mut best_left: Vec<usize> = Vec::new();
         let mut best_right: Vec<usize> = Vec::new();
 
-        // One par_iter over features; each task does its own sort. The
-        // closure returns the per-feature best split (or None) — no
-        // shared scratch between tasks.
+        if n_samples < 2 {
+            return (best_feature, best_threshold, best_left, best_right);
+        }
+        let n_f: F = n_samples.as_();
+
+        // Per-node precomputation shared (read-only) by all feature tasks.
+        // Regression: targets as F, aligned with `indices` positions.
+        let ys_by_pos: Vec<F> = if self.tree_type == TreeType::Regression {
+            indices.iter().map(|&i| target[i].as_()).collect()
+        } else {
+            Vec::new()
+        };
+        // Classification: sorted unique classes + class id per position.
+        // Binary search over PartialOrd — no Eq/Hash bound needed.
+        let (n_classes, ids_by_pos) = if self.tree_type == TreeType::Classification {
+            let mut classes: Vec<T> = indices.iter().map(|&i| target[i]).collect();
+            classes.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+            classes.dedup_by(|a, b| {
+                (*a).partial_cmp(&*b).unwrap_or(Ordering::Less) == Ordering::Equal
+            });
+            let ids: Vec<usize> = indices
+                .iter()
+                .map(|&i| {
+                    classes
+                        .binary_search_by(|c| {
+                            c.partial_cmp(&target[i]).unwrap_or(Ordering::Equal)
+                        })
+                        .unwrap_or(0)
+                })
+                .collect();
+            (classes.len(), ids)
+        } else {
+            (0, Vec::new())
+        };
+
+        // One par_iter over features; each task owns its sort + sweep.
         let results: Vec<_> = (0..n_features)
             .into_par_iter()
             .filter_map(|feature_idx| {
-                // Sort the node's indices by this feature's value (stable
-                // ordering on ties is fine; we skip across ties below).
-                let mut sorted_indices: Vec<usize> = indices.to_vec();
-                sorted_indices.sort_by(|&a, &b| {
-                    features[a][feature_idx]
-                        .partial_cmp(&features[b][feature_idx])
-                        .unwrap_or(Ordering::Equal)
-                });
-                let n = sorted_indices.len();
-                if n < 2 {
-                    return None;
-                }
+                // Contiguous (value, position) pairs: one cache-friendly
+                // sort instead of comparator-driven double indirection
+                // into the row-major feature matrix.
+                let mut pairs: Vec<(D, usize)> = (0..n_samples)
+                    .map(|p| (features[indices[p]][feature_idx], p))
+                    .collect();
+                pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
 
                 let two = F::from(2.0)?;
-
-                // Walk candidate split positions. A split at `split_pos`
-                // means left = sorted_indices[..split_pos],
-                // right = sorted_indices[split_pos..]. Only positions
-                // between two distinct feature values are candidates.
                 let mut feature_best_impurity = F::infinity();
                 let mut feature_best_split_pos: Option<usize> = None;
-                let mut feature_best_threshold = features[sorted_indices[0]][feature_idx];
+                let mut feature_best_threshold = pairs[0].0;
 
-                for split_pos in 1..n {
-                    let i_prev = sorted_indices[split_pos - 1];
-                    let i_curr = sorted_indices[split_pos];
-                    let v_prev = features[i_prev][feature_idx];
-                    let v_curr = features[i_curr][feature_idx];
-                    if v_prev.partial_cmp(&v_curr).unwrap_or(Ordering::Equal) == Ordering::Equal {
-                        continue; // tied feature value; threshold can't separate these
-                    }
-                    let left = &sorted_indices[..split_pos];
-                    let right = &sorted_indices[split_pos..];
-                    if left.len() < self.min_samples_leaf || right.len() < self.min_samples_leaf {
-                        continue;
-                    }
-                    let impurity = self.calculate_split_impurity(target, left, right);
-                    if impurity < feature_best_impurity {
-                        let v1: F = v_prev.as_();
-                        let v2: F = v_curr.as_();
-                        let mid = (v1 + v2) / two;
-                        let threshold: D = match NumCast::from(mid) {
-                            Some(t) => t,
-                            None => continue,
-                        };
+                // A position is a candidate when both sides satisfy
+                // min_samples_leaf and the two adjacent feature values
+                // differ (a threshold can't separate tied values).
+                let is_candidate = |split_pos: usize| {
+                    split_pos >= self.min_samples_leaf
+                        && n_samples - split_pos >= self.min_samples_leaf
+                        && pairs[split_pos - 1]
+                            .0
+                            .partial_cmp(&pairs[split_pos].0)
+                            .unwrap_or(Ordering::Equal)
+                            != Ordering::Equal
+                };
+                let mut consider = |split_pos: usize, impurity: F| {
+                    if impurity < feature_best_impurity
+                        && let Some(thr) = Self::midpoint_threshold(
+                            pairs[split_pos - 1].0,
+                            pairs[split_pos].0,
+                            two,
+                        )
+                    {
                         feature_best_impurity = impurity;
                         feature_best_split_pos = Some(split_pos);
-                        feature_best_threshold = threshold;
+                        feature_best_threshold = thr;
                     }
+                };
+
+                match (self.tree_type, self.criterion) {
+                    (TreeType::Regression, SplitCriterion::Mse) => {
+                        let ys: Vec<F> = pairs.iter().map(|&(_, p)| ys_by_pos[p]).collect();
+                        let mut total_sum = F::zero();
+                        let mut total_sq = F::zero();
+                        for &y in &ys {
+                            total_sum = total_sum + y;
+                            total_sq = total_sq + y * y;
+                        }
+                        let mut left_sum = F::zero();
+                        let mut left_sq = F::zero();
+                        for split_pos in 1..n_samples {
+                            let y = ys[split_pos - 1];
+                            left_sum = left_sum + y;
+                            left_sq = left_sq + y * y;
+                            if !is_candidate(split_pos) {
+                                continue;
+                            }
+                            let nl: F = split_pos.as_();
+                            let nr: F = (n_samples - split_pos).as_();
+                            let right_sum = total_sum - left_sum;
+                            let right_sq = total_sq - left_sq;
+                            // SSE = Σy² − (Σy)²/n, clamped: cancellation can
+                            // push it a hair below zero.
+                            let sse_l = (left_sq - left_sum * left_sum / nl).max(F::zero());
+                            let sse_r = (right_sq - right_sum * right_sum / nr).max(F::zero());
+                            consider(split_pos, (sse_l + sse_r) / n_f);
+                        }
+                    }
+                    (TreeType::Regression, SplitCriterion::Mae) => {
+                        let ys: Vec<F> = pairs.iter().map(|&(_, p)| ys_by_pos[p]).collect();
+                        let mut scratch: Vec<F> = Vec::with_capacity(n_samples);
+                        for split_pos in 1..n_samples {
+                            if !is_candidate(split_pos) {
+                                continue;
+                            }
+                            let sae_l = Self::sum_abs_dev_median(&ys[..split_pos], &mut scratch);
+                            let sae_r = Self::sum_abs_dev_median(&ys[split_pos..], &mut scratch);
+                            consider(split_pos, (sae_l + sae_r) / n_f);
+                        }
+                    }
+                    (TreeType::Classification, SplitCriterion::Gini)
+                    | (TreeType::Classification, SplitCriterion::Entropy) => {
+                        let ids: Vec<usize> = pairs.iter().map(|&(_, p)| ids_by_pos[p]).collect();
+                        let entropy = self.criterion == SplitCriterion::Entropy;
+                        let mut left_counts = vec![0usize; n_classes];
+                        let mut right_counts = vec![0usize; n_classes];
+                        for &id in &ids {
+                            right_counts[id] += 1;
+                        }
+                        for split_pos in 1..n_samples {
+                            let id = ids[split_pos - 1];
+                            left_counts[id] += 1;
+                            right_counts[id] -= 1;
+                            if !is_candidate(split_pos) {
+                                continue;
+                            }
+                            let nl: F = split_pos.as_();
+                            let nr: F = (n_samples - split_pos).as_();
+                            let imp_l = Self::counts_impurity(&left_counts, nl, entropy);
+                            let imp_r = Self::counts_impurity(&right_counts, nr, entropy);
+                            consider(split_pos, (nl * imp_l + nr * imp_r) / n_f);
+                        }
+                    }
+                    // Invalid tree-type/criterion combination: no split.
+                    _ => return None,
                 }
 
-                // Materialise the best split's index vectors only once.
+                // Materialise the best split's global index vectors only once.
                 feature_best_split_pos.map(|split_pos| {
-                    let (left, right) = sorted_indices.split_at(split_pos);
+                    let left: Vec<usize> =
+                        pairs[..split_pos].iter().map(|&(_, p)| indices[p]).collect();
+                    let right: Vec<usize> =
+                        pairs[split_pos..].iter().map(|&(_, p)| indices[p]).collect();
                     (
                         feature_idx,
                         feature_best_impurity,
                         feature_best_threshold,
-                        left.to_vec(),
-                        right.to_vec(),
+                        left,
+                        right,
                     )
                 })
             })
@@ -389,149 +493,62 @@ where
         (best_feature, best_threshold, best_left, best_right)
     }
 
-    /// Calculate the impurity of a split
-    fn calculate_split_impurity(
-        &self,
-        target: &[T],
-        left_indices: &[usize],
-        right_indices: &[usize],
-    ) -> F {
-        let n_left = left_indices.len();
-        let n_right = right_indices.len();
-        let n_total = n_left + n_right;
-
-        if n_left == 0 || n_right == 0 {
-            return F::infinity();
-        }
-
-        let left_weight: F = (n_left as f64).as_();
-        let right_weight: F = (n_right as f64).as_();
-        let total: F = (n_total as f64).as_();
-
-        let left_ratio = left_weight / total;
-        let right_ratio = right_weight / total;
-
-        match (self.tree_type, self.criterion) {
-            (TreeType::Regression, SplitCriterion::Mse) => {
-                // Mean squared error
-                let left_mse = self.calculate_mse(target, left_indices);
-                let right_mse = self.calculate_mse(target, right_indices);
-                left_ratio * left_mse + right_ratio * right_mse
-            }
-            (TreeType::Regression, SplitCriterion::Mae) => {
-                // Mean absolute error
-                let left_mae = self.calculate_mae(target, left_indices);
-                let right_mae = self.calculate_mae(target, right_indices);
-                left_ratio * left_mae + right_ratio * right_mae
-            }
-            (TreeType::Classification, SplitCriterion::Gini) => {
-                // Gini impurity
-                let left_gini = self.calculate_gini(target, left_indices);
-                let right_gini = self.calculate_gini(target, right_indices);
-                left_ratio * left_gini + right_ratio * right_gini
-            }
-            (TreeType::Classification, SplitCriterion::Entropy) => {
-                // Entropy
-                let left_entropy = self.calculate_entropy(target, left_indices);
-                let right_entropy = self.calculate_entropy(target, right_indices);
-                left_ratio * left_entropy + right_ratio * right_entropy
-            }
-            _ => {
-                // This should never happen if the tree is properly constructed
-                // Return infinity as a sentinel value that will be ignored
-                F::infinity()
-            }
-        }
+    /// Midpoint of two adjacent feature values, converted back to `D`.
+    #[inline]
+    fn midpoint_threshold<D>(v_prev: D, v_curr: D, two: F) -> Option<D>
+    where
+        D: Copy + NumCast + AsPrimitive<F>,
+    {
+        let v1: F = v_prev.as_();
+        let v2: F = v_curr.as_();
+        NumCast::from((v1 + v2) / two)
     }
 
-    /// Calculate the mean squared error for a set of samples
-    fn calculate_mse(&self, target: &[T], indices: &[usize]) -> F {
-        if indices.is_empty() {
-            return F::zero();
-        }
-
-        // If calculate_mean fails, return infinity to make this split undesirable
-        let mean = match self.calculate_mean(target, indices) {
-            Ok(m) => m,
-            Err(_) => return F::infinity(),
-        };
-        let mean_f: F = mean.as_();
-
-        let sum_squared_error: F = indices
-            .iter()
-            .map(|&idx| {
-                let error: F = target[idx].as_() - mean_f;
-                error * error
-            })
-            .fold(F::zero(), |a, b| a + b);
-
-        let count = F::from(indices.len()).unwrap_or(F::one());
-        sum_squared_error / count
-    }
-
-    /// Calculate the mean absolute error for a set of samples
-    fn calculate_mae(&self, target: &[T], indices: &[usize]) -> F {
-        if indices.is_empty() {
-            return F::zero();
-        }
-
-        // If calculate_mean fails, return infinity to make this split undesirable
-        let mean = match self.calculate_mean(target, indices) {
-            Ok(m) => m,
-            Err(_) => return F::infinity(),
-        };
-        let mean_f: F = mean.as_();
-
-        let sum_absolute_error: F = indices
-            .iter()
-            .map(|&idx| {
-                let error: F = target[idx].as_() - mean_f;
-                error.abs()
-            })
-            .fold(F::zero(), |a, b| a + b);
-
-        let count = F::from(indices.len()).unwrap_or(F::one());
-        sum_absolute_error / count
-    }
-
-    /// Calculate the Gini impurity for a set of samples
-    fn calculate_gini(&self, target: &[T], indices: &[usize]) -> F {
-        if indices.is_empty() {
-            return F::zero();
-        }
-
-        let (_, class_counts) = self.calculate_class_distribution(target, indices);
-        let n_samples = indices.len();
-
-        F::one()
-            - class_counts
-                .values()
-                .map(|&count| {
-                    let probability: F = (count as f64 / n_samples as f64).as_();
-                    probability * probability
+    /// Gini or entropy impurity from class counts (`n_side` = Σ counts).
+    fn counts_impurity(counts: &[usize], n_side: F, entropy: bool) -> F {
+        if entropy {
+            -counts
+                .iter()
+                .filter(|&&c| c > 0)
+                .map(|&c| {
+                    let p: F = c.as_() / n_side;
+                    p * p.ln()
                 })
                 .fold(F::zero(), |a, b| a + b)
+        } else {
+            F::one()
+                - counts
+                    .iter()
+                    .map(|&c| {
+                        let p: F = c.as_() / n_side;
+                        p * p
+                    })
+                    .fold(F::zero(), |a, b| a + b)
+        }
     }
 
-    /// Calculate the entropy for a set of samples
-    fn calculate_entropy(&self, target: &[T], indices: &[usize]) -> F {
-        if indices.is_empty() {
-            return F::zero();
-        }
-
-        let (_, class_counts) = self.calculate_class_distribution(target, indices);
-        let n_samples = indices.len();
-
-        -class_counts
-            .values()
-            .map(|&count| {
-                let probability: F = (count as f64 / n_samples as f64).as_();
-                if probability > F::zero() {
-                    probability * probability.ln()
-                } else {
-                    F::zero()
-                }
-            })
+    /// Sum of |y − median(ys)| — the MAE numerator. The median (not the
+    /// mean) is the MAE minimiser; centring on the mean, as done before
+    /// v3.1, computed a different quantity ("mean absolute deviation
+    /// around the mean") under the MAE name.
+    fn sum_abs_dev_median(ys: &[F], scratch: &mut Vec<F>) -> F {
+        scratch.clear();
+        scratch.extend_from_slice(ys);
+        let n = scratch.len();
+        let mid = n / 2;
+        scratch
+            .select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        let median = if n % 2 == 1 {
+            scratch[mid]
+        } else {
+            let lower = scratch[..mid]
+                .iter()
+                .cloned()
+                .fold(F::neg_infinity(), F::max);
+            (lower + scratch[mid]) / (F::one() + F::one())
+        };
+        ys.iter()
+            .map(|&y| (y - median).abs())
             .fold(F::zero(), |a, b| a + b)
     }
 
@@ -561,30 +578,56 @@ where
         })
     }
 
-    /// Calculate the class distribution and majority class for a set of samples
-    fn calculate_class_distribution(
-        &self,
-        target: &[T],
-        indices: &[usize],
-    ) -> (T, HashMap<T, usize>) {
-        let mut class_counts: HashMap<T, usize> = HashMap::new();
+    /// Calculate the class distribution (sorted by class) and the majority
+    /// class for a set of samples. Sort + run-length encode: only needs
+    /// `PartialOrd` on `T`, unlike the previous HashMap (`Eq + Hash`),
+    /// which made `DecisionTree<f64, _>` impossible.
+    fn calculate_class_distribution(&self, target: &[T], indices: &[usize]) -> (T, Vec<(T, usize)>) {
+        let mut values: Vec<T> = indices.iter().map(|&idx| target[idx]).collect();
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
 
-        for &idx in indices {
-            let class = target[idx];
-            *class_counts.entry(class).or_insert(0) += 1;
+        let mut class_counts: Vec<(T, usize)> = Vec::new();
+        for v in values {
+            match class_counts.last_mut() {
+                Some((c, n))
+                    if (*c).partial_cmp(&v).unwrap_or(Ordering::Less) == Ordering::Equal =>
+                {
+                    *n += 1;
+                }
+                _ => class_counts.push((v, 1)),
+            }
         }
 
-        // Find the majority class
-        let (majority_class, _) = class_counts
+        let majority_class = class_counts
             .iter()
-            .max_by_key(|&(_, count)| *count)
-            .map(|(&class, count)| (class, *count))
-            .unwrap_or_else(|| {
-                // Default value if empty (should never happen)
-                (NumCast::from(0.0).unwrap(), 0)
-            });
+            .max_by_key(|(_, count)| *count)
+            .map(|(class, _)| class.clone())
+            .unwrap_or_else(|| NumCast::from(0.0).unwrap());
 
         (majority_class, class_counts)
+    }
+
+    /// Median of target values — the MAE-optimal leaf prediction
+    /// (converted back to `T`, which may round for integer targets).
+    fn calculate_median(&self, target: &[T], indices: &[usize]) -> StatsResult<T> {
+        if indices.is_empty() {
+            return Err(StatsError::empty_data(
+                "Cannot calculate median for empty indices",
+            ));
+        }
+        let mut vals: Vec<F> = indices.iter().map(|&i| target[i].as_()).collect();
+        let n = vals.len();
+        let mid = n / 2;
+        vals.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        let median = if n % 2 == 1 {
+            vals[mid]
+        } else {
+            let lower = vals[..mid].iter().cloned().fold(F::neg_infinity(), F::max);
+            (lower + vals[mid]) / (F::one() + F::one())
+        };
+        NumCast::from(median).ok_or_else(|| {
+            StatsError::conversion_error("Failed to convert median to the target type".to_string())
+        })
     }
 
     /// Check if all samples in the current set have the same target value
@@ -776,7 +819,7 @@ where
 
 impl<T, F> fmt::Display for DecisionTree<T, F>
 where
-    T: Clone + PartialOrd + Eq + Hash + Debug + ToPrimitive,
+    T: Clone + PartialOrd + Debug + ToPrimitive,
     F: Float,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -794,7 +837,7 @@ where
 /// Implementation of additional methods for enhanced usability
 impl<T, F> DecisionTree<T, F>
 where
-    T: Clone + PartialOrd + Eq + Hash + Send + Sync + NumCast + ToPrimitive + Debug,
+    T: Clone + PartialOrd + Send + Sync + NumCast + ToPrimitive + Debug,
     F: Float + Send + Sync + NumCast + FromPrimitive + 'static,
     f64: AsPrimitive<F>,
     usize: AsPrimitive<F>,
@@ -830,7 +873,7 @@ where
         // Helper function to calculate the depth recursively
         fn depth_helper<T, F>(nodes: &[Node<T, F>], node_idx: usize, current_depth: usize) -> usize
         where
-            T: Clone + PartialOrd + Eq + Hash + Debug + ToPrimitive,
+            T: Clone + PartialOrd + Debug + ToPrimitive,
             F: Float,
         {
             let node = &nodes[node_idx];
@@ -1428,6 +1471,56 @@ mod tests {
             result.unwrap_err(),
             StatsError::InvalidInput { .. }
         ));
+    }
+
+    #[test]
+    fn test_f64_regression_target_compiles_and_fits() {
+        // The headline of the v3.1 tree refactor: f64 targets no longer
+        // need a wrapper type (the old `Eq + Hash` bound made
+        // `DecisionTree<f64, f64>` a compile error).
+        let mut tree =
+            DecisionTree::<f64, f64>::new(TreeType::Regression, SplitCriterion::Mse, 4, 2, 1);
+        let features: Vec<Vec<f64>> = (0..40).map(|i| vec![i as f64]).collect();
+        let target: Vec<f64> = (0..40)
+            .map(|i| if i < 20 { 1.0 + (i % 3) as f64 * 0.01 } else { 10.0 })
+            .collect();
+        tree.fit(&features, &target).unwrap();
+
+        let preds = tree.predict(&vec![vec![5.0], vec![30.0]]).unwrap();
+        assert!((preds[0] - 1.0).abs() < 0.1, "pred low = {}", preds[0]);
+        assert!((preds[1] - 10.0).abs() < 0.1, "pred high = {}", preds[1]);
+    }
+
+    #[test]
+    fn test_mae_leaf_predicts_median() {
+        // With an outlier, the median (MAE-optimal) differs from the mean:
+        // max_depth = 0 forces a single leaf so we observe the raw leaf value.
+        let mut tree =
+            DecisionTree::<f64, f64>::new(TreeType::Regression, SplitCriterion::Mae, 0, 2, 1);
+        let features: Vec<Vec<f64>> = (0..5).map(|i| vec![i as f64]).collect();
+        let target = vec![1.0, 2.0, 3.0, 4.0, 100.0];
+        tree.fit(&features, &target).unwrap();
+        let pred = tree.predict(&vec![vec![2.0]]).unwrap()[0];
+        assert!((pred - 3.0).abs() < 1e-12, "MAE leaf = {pred} (median is 3, mean is 22)");
+    }
+
+    #[test]
+    fn test_mse_split_matches_bruteforce() {
+        // The incremental SSE sweep must select the same split as an
+        // explicit brute-force evaluation.
+        let features: Vec<Vec<f64>> = vec![
+            vec![1.0], vec![2.0], vec![3.0], vec![4.0], vec![10.0], vec![11.0], vec![12.0],
+        ];
+        let target = vec![5.0, 5.1, 4.9, 5.0, 20.0, 20.2, 19.8];
+        let mut tree =
+            DecisionTree::<f64, f64>::new(TreeType::Regression, SplitCriterion::Mse, 1, 2, 1);
+        tree.fit(&features, &target).unwrap();
+        // Best split must separate {1..4} from {10..12}: threshold in (4, 10).
+        let s = tree.tree_structure();
+        assert!(s.contains("feature 0"), "structure: {s}");
+        let preds = tree.predict(&vec![vec![2.0], vec![11.0]]).unwrap();
+        assert!((preds[0] - 5.0).abs() < 0.1);
+        assert!((preds[1] - 20.0).abs() < 0.2);
     }
 
     #[test]

--- a/src/regression/decision_tree.rs
+++ b/src/regression/decision_tree.rs
@@ -342,9 +342,7 @@ where
                 .iter()
                 .map(|&i| {
                     classes
-                        .binary_search_by(|c| {
-                            c.partial_cmp(&target[i]).unwrap_or(Ordering::Equal)
-                        })
+                        .binary_search_by(|c| c.partial_cmp(&target[i]).unwrap_or(Ordering::Equal))
                         .unwrap_or(0)
                 })
                 .collect();
@@ -469,10 +467,14 @@ where
 
                 // Materialise the best split's global index vectors only once.
                 feature_best_split_pos.map(|split_pos| {
-                    let left: Vec<usize> =
-                        pairs[..split_pos].iter().map(|&(_, p)| indices[p]).collect();
-                    let right: Vec<usize> =
-                        pairs[split_pos..].iter().map(|&(_, p)| indices[p]).collect();
+                    let left: Vec<usize> = pairs[..split_pos]
+                        .iter()
+                        .map(|&(_, p)| indices[p])
+                        .collect();
+                    let right: Vec<usize> = pairs[split_pos..]
+                        .iter()
+                        .map(|&(_, p)| indices[p])
+                        .collect();
                     (
                         feature_idx,
                         feature_best_impurity,
@@ -540,8 +542,7 @@ where
         scratch.extend_from_slice(ys);
         let n = scratch.len();
         let mid = n / 2;
-        scratch
-            .select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        scratch.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
         let median = if n % 2 == 1 {
             scratch[mid]
         } else {
@@ -586,7 +587,11 @@ where
     /// class for a set of samples. Sort + run-length encode: only needs
     /// `PartialOrd` on `T`, unlike the previous HashMap (`Eq + Hash`),
     /// which made `DecisionTree<f64, _>` impossible.
-    fn calculate_class_distribution(&self, target: &[T], indices: &[usize]) -> (T, Vec<(T, usize)>) {
+    fn calculate_class_distribution(
+        &self,
+        target: &[T],
+        indices: &[usize],
+    ) -> (T, Vec<(T, usize)>) {
         let mut values: Vec<T> = indices.iter().map(|&idx| target[idx]).collect();
         values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
 
@@ -1486,7 +1491,13 @@ mod tests {
             DecisionTree::<f64, f64>::new(TreeType::Regression, SplitCriterion::Mse, 4, 2, 1);
         let features: Vec<Vec<f64>> = (0..40).map(|i| vec![i as f64]).collect();
         let target: Vec<f64> = (0..40)
-            .map(|i| if i < 20 { 1.0 + (i % 3) as f64 * 0.01 } else { 10.0 })
+            .map(|i| {
+                if i < 20 {
+                    1.0 + (i % 3) as f64 * 0.01
+                } else {
+                    10.0
+                }
+            })
             .collect();
         tree.fit(&features, &target).unwrap();
 
@@ -1505,7 +1516,10 @@ mod tests {
         let target = vec![1.0, 2.0, 3.0, 4.0, 100.0];
         tree.fit(&features, &target).unwrap();
         let pred = tree.predict(&vec![vec![2.0]]).unwrap()[0];
-        assert!((pred - 3.0).abs() < 1e-12, "MAE leaf = {pred} (median is 3, mean is 22)");
+        assert!(
+            (pred - 3.0).abs() < 1e-12,
+            "MAE leaf = {pred} (median is 3, mean is 22)"
+        );
     }
 
     #[test]
@@ -1513,7 +1527,13 @@ mod tests {
         // The incremental SSE sweep must select the same split as an
         // explicit brute-force evaluation.
         let features: Vec<Vec<f64>> = vec![
-            vec![1.0], vec![2.0], vec![3.0], vec![4.0], vec![10.0], vec![11.0], vec![12.0],
+            vec![1.0],
+            vec![2.0],
+            vec![3.0],
+            vec![4.0],
+            vec![10.0],
+            vec![11.0],
+            vec![12.0],
         ];
         let target = vec![5.0, 5.1, 4.9, 5.0, 20.0, 20.2, 19.8];
         let mut tree =

--- a/src/regression/decision_tree.rs
+++ b/src/regression/decision_tree.rs
@@ -399,7 +399,15 @@ where
 
                 match (self.tree_type, self.criterion) {
                     (TreeType::Regression, SplitCriterion::Mse) => {
-                        let ys: Vec<F> = pairs.iter().map(|&(_, p)| ys_by_pos[p]).collect();
+                        let mut ys: Vec<F> = pairs.iter().map(|&(_, p)| ys_by_pos[p]).collect();
+                        // Centre on the node mean before accumulating:
+                        // Σy² − (Σy)²/n cancels catastrophically when
+                        // mean² ≫ variance (timestamps, amounts). SSE is
+                        // shift-invariant, so the split choice is identical.
+                        let node_mean = ys.iter().fold(F::zero(), |a, &b| a + b) / n_f;
+                        for y in ys.iter_mut() {
+                            *y = *y - node_mean;
+                        }
                         let mut total_sum = F::zero();
                         let mut total_sq = F::zero();
                         for &y in &ys {

--- a/src/regression/decision_tree.rs
+++ b/src/regression/decision_tree.rs
@@ -1,6 +1,7 @@
 use crate::error::{StatsError, StatsResult};
 use num_traits::cast::AsPrimitive;
 use num_traits::{Float, FromPrimitive, NumCast, ToPrimitive};
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug};
@@ -353,8 +354,11 @@ where
         };
 
         // One par_iter over features; each task owns its sort + sweep.
-        let results: Vec<_> = (0..n_features)
-            .into_par_iter()
+        #[cfg(feature = "parallel")]
+        let feature_iter = (0..n_features).into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let feature_iter = 0..n_features;
+        let results: Vec<_> = feature_iter
             .filter_map(|feature_idx| {
                 // Contiguous (value, position) pairs: one cache-friendly
                 // sort instead of comparator-driven double indirection

--- a/src/regression/linear_regression.rs
+++ b/src/regression/linear_regression.rs
@@ -25,6 +25,13 @@ where
     pub standard_error: T,
     /// Number of data points used for regression
     pub n: usize,
+    /// Mean of the fitted X values (needed for confidence intervals).
+    /// `#[serde(default)]` keeps pre-v3.1 saved models loadable.
+    #[serde(default)]
+    pub x_mean: T,
+    /// Sum of squared deviations of X around its mean, `Σ(xᵢ−x̄)²`.
+    #[serde(default)]
+    pub sum_xx: T,
 }
 
 impl<T> Default for LinearRegression<T>
@@ -48,6 +55,8 @@ where
             r_squared: T::zero(),
             standard_error: T::zero(),
             n: 0,
+            x_mean: T::zero(),
+            sum_xx: T::zero(),
         }
     }
 
@@ -146,6 +155,8 @@ where
         // Calculate slope and intercept
         self.slope = sum_xy / sum_xx;
         self.intercept = y_mean - (self.slope * x_mean);
+        self.x_mean = x_mean;
+        self.sum_xx = sum_xx;
 
         // Calculate R²
         self.r_squared = (sum_xy * sum_xy) / (sum_xx * sum_yy);
@@ -244,20 +255,11 @@ where
         x_values.par_iter().map(|&x| self.predict(x)).collect()
     }
 
-    /// Calculate confidence intervals for the regression line
+    /// Shared machinery for confidence / prediction intervals.
     ///
-    /// # Arguments
-    /// * `x` - The x value to calculate confidence interval for
-    /// * `confidence_level` - Confidence level (0.95 for 95% confidence)
-    ///
-    /// # Returns
-    /// * `StatsResult<(T, T)>` - Tuple of (lower_bound, upper_bound), or an error if invalid
-    ///
-    /// # Errors
-    /// Returns `StatsError::InvalidInput` if there are fewer than 3 data points.
-    /// Returns `StatsError::InvalidParameter` if confidence level is not supported (only 0.90, 0.95, 0.99).
-    /// Returns `StatsError::ConversionError` if value conversion fails.
-    pub fn confidence_interval<U>(&self, x: U, confidence_level: f64) -> StatsResult<(T, T)>
+    /// `extra` is 0 for the CI of the mean response and 1 for a prediction
+    /// interval (adds the variance of a single new observation).
+    fn t_interval<U>(&self, x: U, confidence_level: f64, extra: f64) -> StatsResult<(T, T)>
     where
         U: NumCast + Copy,
     {
@@ -266,34 +268,82 @@ where
                 "Need at least 3 data points to calculate confidence interval",
             ));
         }
+        if !(0.0..1.0).contains(&confidence_level) || confidence_level <= 0.0 {
+            return Err(StatsError::invalid_parameter(format!(
+                "Confidence level must be in (0, 1), got {confidence_level}"
+            )));
+        }
+        if self.sum_xx <= T::zero() {
+            return Err(StatsError::invalid_input(
+                "Model was fitted without X dispersion info (pre-v3.1 saved model?); refit before computing intervals",
+            ));
+        }
 
         let x_cast: T = T::from(x)
             .ok_or_else(|| StatsError::conversion_error("Failed to convert x value to type T"))?;
 
-        // Get the t-critical value based on degrees of freedom and confidence level
-        // For simplicity, we'll use a normal approximation with standard errors
-        let z_score: T = match confidence_level {
-            0.90 => T::from(1.645).ok_or_else(|| {
-                StatsError::conversion_error("Failed to convert z-score 1.645 to type T")
-            })?,
-            0.95 => T::from(1.96).ok_or_else(|| {
-                StatsError::conversion_error("Failed to convert z-score 1.96 to type T")
-            })?,
-            0.99 => T::from(2.576).ok_or_else(|| {
-                StatsError::conversion_error("Failed to convert z-score 2.576 to type T")
-            })?,
-            _ => {
-                return Err(StatsError::invalid_parameter(format!(
-                    "Unsupported confidence level: {}. Supported values: 0.90, 0.95, 0.99",
-                    confidence_level
-                )));
-            }
-        };
+        // Student-t critical value with n − 2 degrees of freedom. The old
+        // implementation used hardcoded *normal* z-scores, which understate
+        // the interval for small n — exactly where intervals matter most.
+        use crate::distributions::student_t::StudentT;
+        use crate::distributions::traits::Distribution as _;
+        let df = (self.n - 2) as f64;
+        let t_crit = StudentT::new(0.0, 1.0, df)?.inverse_cdf(0.5 * (1.0 + confidence_level))?;
+        let t_crit: T = T::from(t_crit)
+            .ok_or_else(|| StatsError::conversion_error("Failed to convert t quantile to type T"))?;
+
+        // SE of the estimate at x: s·√(extra + 1/n + (x−x̄)²/Sxx).
+        // The band widens away from x̄ — a constant ±t·s is neither a CI of
+        // the mean response nor a prediction interval.
+        let n_t = T::from(self.n)
+            .ok_or_else(|| StatsError::conversion_error("Failed to convert n to type T"))?;
+        let extra_t = T::from(extra)
+            .ok_or_else(|| StatsError::conversion_error("Failed to convert constant to type T"))?;
+        let dx = x_cast - self.x_mean;
+        let se_at_x =
+            self.standard_error * (extra_t + T::one() / n_t + dx * dx / self.sum_xx).sqrt();
 
         let predicted = self.predict_t(x_cast);
-        let margin = z_score * self.standard_error;
-
+        let margin = t_crit * se_at_x;
         Ok((predicted - margin, predicted + margin))
+    }
+
+    /// Confidence interval for the **mean response** `E[Y | x]` at `x`.
+    ///
+    /// Uses Student-t quantiles with `n − 2` degrees of freedom and the
+    /// standard error `s·√(1/n + (x−x̄)²/Sxx)`, so the band widens away
+    /// from the centre of the data. Any `confidence_level` in (0, 1) is
+    /// accepted (0.95 for 95% confidence).
+    ///
+    /// For bounds on a single future *observation*, use
+    /// [`prediction_interval`](Self::prediction_interval) instead.
+    ///
+    /// # Returns
+    /// * `StatsResult<(T, T)>` - Tuple of (lower_bound, upper_bound), or an error if invalid
+    ///
+    /// # Errors
+    /// Returns `StatsError::InvalidInput` if there are fewer than 3 data points.
+    /// Returns `StatsError::InvalidParameter` if `confidence_level` is not in (0, 1).
+    /// Returns `StatsError::ConversionError` if value conversion fails.
+    pub fn confidence_interval<U>(&self, x: U, confidence_level: f64) -> StatsResult<(T, T)>
+    where
+        U: NumCast + Copy,
+    {
+        self.t_interval(x, confidence_level, 0.0)
+    }
+
+    /// Prediction interval for a **single future observation** at `x`.
+    ///
+    /// Wider than [`confidence_interval`](Self::confidence_interval): adds
+    /// the variance of one new observation, `s·√(1 + 1/n + (x−x̄)²/Sxx)`.
+    ///
+    /// # Errors
+    /// Same as [`confidence_interval`](Self::confidence_interval).
+    pub fn prediction_interval<U>(&self, x: U, confidence_level: f64) -> StatsResult<(T, T)>
+    where
+        U: NumCast + Copy,
+    {
+        self.t_interval(x, confidence_level, 1.0)
     }
 
     /// Get the correlation coefficient (r)
@@ -662,19 +712,44 @@ mod tests {
     }
 
     #[test]
-    fn test_confidence_interval_unsupported_level() {
-        // Test confidence_interval with unsupported confidence level
+    fn test_confidence_interval_levels() {
         let mut model = LinearRegression::<f64>::new();
         let x = vec![1.0, 2.0, 3.0, 4.0];
-        let y = vec![2.0, 4.0, 6.0, 8.0];
+        let y = vec![2.1, 3.9, 6.2, 7.8];
         model.fit(&x, &y).unwrap();
 
-        let result = model.confidence_interval(3.0, 0.85);
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            StatsError::InvalidParameter { .. }
-        ));
+        // Any level in (0, 1) is accepted — including non-standard ones.
+        let (lo85, hi85) = model.confidence_interval(3.0, 0.85).unwrap();
+        let (lo95, hi95) = model.confidence_interval(3.0, 0.95).unwrap();
+        assert!(lo95 < lo85 && hi85 < hi95, "higher level ⇒ wider interval");
+
+        // Levels outside (0, 1) are rejected.
+        for bad in [0.0, 1.0, 1.5, -0.1] {
+            assert!(matches!(
+                model.confidence_interval(3.0, bad).unwrap_err(),
+                StatsError::InvalidParameter { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn test_interval_geometry() {
+        let mut model = LinearRegression::<f64>::new();
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+        let y = vec![2.1, 4.0, 5.9, 8.1, 10.0, 12.2, 13.8];
+        model.fit(&x, &y).unwrap();
+
+        // The CI band must widen away from x̄ (= 4.0 here).
+        let w = |x0: f64| {
+            let (lo, hi) = model.confidence_interval(x0, 0.95).unwrap();
+            hi - lo
+        };
+        assert!(w(1.0) > w(4.0) && w(7.0) > w(4.0));
+
+        // A prediction interval is strictly wider than the CI of the mean.
+        let (ci_lo, ci_hi) = model.confidence_interval(4.0, 0.95).unwrap();
+        let (pi_lo, pi_hi) = model.prediction_interval(4.0, 0.95).unwrap();
+        assert!(pi_lo < ci_lo && ci_hi < pi_hi);
     }
 
     #[test]

--- a/src/regression/linear_regression.rs
+++ b/src/regression/linear_regression.rs
@@ -32,7 +32,7 @@ where
     /// Number of data points used for regression
     pub n: usize,
     /// Mean of the fitted X values (needed for confidence intervals).
-    /// `serde(default)` keeps pre-v3.1 saved models loadable.
+    /// `serde(default)` keeps pre-v4.0 saved models loadable.
     #[cfg_attr(feature = "serde", serde(default))]
     pub x_mean: T,
     /// Sum of squared deviations of X around its mean, `Σ(xᵢ−x̄)²`.
@@ -290,7 +290,7 @@ where
         }
         if self.sum_xx <= T::zero() {
             return Err(StatsError::invalid_input(
-                "Model was fitted without X dispersion info (pre-v3.1 saved model?); refit before computing intervals",
+                "Model was fitted without X dispersion info (pre-v4.0 saved model?); refit before computing intervals",
             ));
         }
 

--- a/src/regression/linear_regression.rs
+++ b/src/regression/linear_regression.rs
@@ -252,7 +252,14 @@ where
         U: NumCast + Copy + Send + Sync,
         T: Send + Sync,
     {
-        x_values.par_iter().map(|&x| self.predict(x)).collect()
+        // Each prediction is two flops; below this size the rayon dispatch
+        // overhead dwarfs the work itself.
+        const PAR_THRESHOLD: usize = 10_000;
+        if x_values.len() < PAR_THRESHOLD {
+            x_values.iter().map(|&x| self.predict(x)).collect()
+        } else {
+            x_values.par_iter().map(|&x| self.predict(x)).collect()
+        }
     }
 
     /// Shared machinery for confidence / prediction intervals.

--- a/src/regression/linear_regression.rs
+++ b/src/regression/linear_regression.rs
@@ -304,8 +304,9 @@ where
         use crate::distributions::traits::Distribution as _;
         let df = (self.n - 2) as f64;
         let t_crit = StudentT::new(0.0, 1.0, df)?.inverse_cdf(0.5 * (1.0 + confidence_level))?;
-        let t_crit: T = T::from(t_crit)
-            .ok_or_else(|| StatsError::conversion_error("Failed to convert t quantile to type T"))?;
+        let t_crit: T = T::from(t_crit).ok_or_else(|| {
+            StatsError::conversion_error("Failed to convert t quantile to type T")
+        })?;
 
         // SE of the estimate at x: s·√(extra + 1/n + (x−x̄)²/Sxx).
         // The band widens away from x̄ — a constant ±t·s is neither a CI of
@@ -391,7 +392,6 @@ where
         let r = self.r_squared.sqrt();
         Ok(if self.slope >= T::zero() { r } else { -r })
     }
-
 }
 
 /// Model persistence — requires the `serde` feature.

--- a/src/regression/linear_regression.rs
+++ b/src/regression/linear_regression.rs
@@ -2,18 +2,24 @@
 
 use crate::error::{StatsError, StatsResult};
 use num_traits::{Float, NumCast};
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+#[cfg(feature = "serde")]
 use std::fs::File;
+#[cfg(feature = "serde")]
 use std::io::{self};
+#[cfg(feature = "serde")]
 use std::path::Path;
 
 /// Linear regression model that fits a line to data points.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LinearRegression<T = f64>
 where
-    T: Float + Debug + Default + Serialize,
+    T: Float + Debug + Default,
 {
     /// Slope of the regression line (coefficient of x)
     pub slope: T,
@@ -26,17 +32,17 @@ where
     /// Number of data points used for regression
     pub n: usize,
     /// Mean of the fitted X values (needed for confidence intervals).
-    /// `#[serde(default)]` keeps pre-v3.1 saved models loadable.
-    #[serde(default)]
+    /// `serde(default)` keeps pre-v3.1 saved models loadable.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub x_mean: T,
     /// Sum of squared deviations of X around its mean, `Σ(xᵢ−x̄)²`.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub sum_xx: T,
 }
 
 impl<T> Default for LinearRegression<T>
 where
-    T: Float + Debug + Default + NumCast + Serialize + for<'de> Deserialize<'de>,
+    T: Float + Debug + Default + NumCast,
 {
     fn default() -> Self {
         Self::new()
@@ -45,7 +51,7 @@ where
 
 impl<T> LinearRegression<T>
 where
-    T: Float + Debug + Default + NumCast + Serialize + for<'de> Deserialize<'de>,
+    T: Float + Debug + Default + NumCast,
 {
     /// Create a new linear regression model without fitting any data
     pub fn new() -> Self {
@@ -254,12 +260,14 @@ where
     {
         // Each prediction is two flops; below this size the rayon dispatch
         // overhead dwarfs the work itself.
-        const PAR_THRESHOLD: usize = 10_000;
-        if x_values.len() < PAR_THRESHOLD {
-            x_values.iter().map(|&x| self.predict(x)).collect()
-        } else {
-            x_values.par_iter().map(|&x| self.predict(x)).collect()
+        #[cfg(feature = "parallel")]
+        {
+            const PAR_THRESHOLD: usize = 10_000;
+            if x_values.len() >= PAR_THRESHOLD {
+                return x_values.par_iter().map(|&x| self.predict(x)).collect();
+            }
         }
+        x_values.iter().map(|&x| self.predict(x)).collect()
     }
 
     /// Shared machinery for confidence / prediction intervals.
@@ -384,6 +392,14 @@ where
         Ok(if self.slope >= T::zero() { r } else { -r })
     }
 
+}
+
+/// Model persistence — requires the `serde` feature.
+#[cfg(feature = "serde")]
+impl<T> LinearRegression<T>
+where
+    T: Float + Debug + Default + NumCast + Serialize + for<'de> Deserialize<'de>,
+{
     /// Save the model to a file
     ///
     /// # Arguments
@@ -460,6 +476,7 @@ where
 mod tests {
     use super::*;
     use crate::utils::approx_equal;
+    #[cfg(feature = "serde")]
     use tempfile::tempdir;
 
     #[test]
@@ -552,6 +569,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_save_load_json() {
         // Create a temporary directory
@@ -580,6 +598,7 @@ mod tests {
         assert_eq!(loaded.n, model.n);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_save_load_binary() {
         // Create a temporary directory
@@ -608,6 +627,7 @@ mod tests {
         assert_eq!(loaded.n, model.n);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_json_serialization() {
         // Create and fit a model
@@ -633,6 +653,7 @@ mod tests {
         assert_eq!(loaded.n, model.n);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_load_nonexistent_file() {
         // Test loading from a file that doesn't exist
@@ -640,6 +661,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_load_binary_nonexistent_file() {
         // Test loading from a binary file that doesn't exist
@@ -647,6 +669,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_from_json_invalid_json() {
         // Test deserializing from invalid JSON
@@ -664,6 +687,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), StatsError::NotFitted { .. }));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_save_invalid_path() {
         // Test saving to an invalid path (non-existent directory)
@@ -839,6 +863,7 @@ mod tests {
         assert!((predictions[1] - 10.0).abs() < 1e-10);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_load_invalid_json() {
         // Test loading invalid JSON
@@ -852,6 +877,7 @@ mod tests {
         assert!(result.is_err(), "Loading invalid JSON should return error");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_from_json_invalid() {
         // Test deserializing invalid JSON string

--- a/src/regression/multiple_linear_regression.rs
+++ b/src/regression/multiple_linear_regression.rs
@@ -254,11 +254,9 @@ where
                         dff / (dff + t * t),
                     )
                     .clamp(0.0, 1.0);
-                    self.coefficient_std_errors.push(
-                        T::from(se).ok_or_else(|| {
-                            StatsError::conversion_error("Failed to convert SE to type T")
-                        })?,
-                    );
+                    self.coefficient_std_errors.push(T::from(se).ok_or_else(|| {
+                        StatsError::conversion_error("Failed to convert SE to type T")
+                    })?);
                     self.t_statistics.push(T::from(t).ok_or_else(|| {
                         StatsError::conversion_error("Failed to convert t to type T")
                     })?);
@@ -401,7 +399,6 @@ where
     {
         x_values.iter().map(|x| self.predict(x)).collect()
     }
-
 }
 
 /// Model persistence — requires the `serde` feature.

--- a/src/regression/multiple_linear_regression.rs
+++ b/src/regression/multiple_linear_regression.rs
@@ -33,7 +33,7 @@ where
     pub p: usize,
     /// Standard error of each coefficient (intercept first):
     /// `SE(βⱼ) = s·√[(XᵀX)⁻¹]ⱼⱼ`. Empty if `n ≤ p + 1` or `XᵀX` is singular.
-    /// `#[serde(default)]` keeps pre-v3.1 saved models loadable.
+    /// `#[serde(default)]` keeps pre-v4.0 saved models loadable.
     #[cfg_attr(feature = "serde", serde(default))]
     pub coefficient_std_errors: Vec<T>,
     /// t-statistic of each coefficient (`βⱼ / SE(βⱼ)`, intercept first).

--- a/src/regression/multiple_linear_regression.rs
+++ b/src/regression/multiple_linear_regression.rs
@@ -26,6 +26,23 @@ where
     pub n: usize,
     /// Number of predictor variables (excluding intercept)
     pub p: usize,
+    /// Standard error of each coefficient (intercept first):
+    /// `SE(βⱼ) = s·√[(XᵀX)⁻¹]ⱼⱼ`. Empty if `n ≤ p + 1` or `XᵀX` is singular.
+    /// `#[serde(default)]` keeps pre-v3.1 saved models loadable.
+    #[serde(default)]
+    pub coefficient_std_errors: Vec<T>,
+    /// t-statistic of each coefficient (`βⱼ / SE(βⱼ)`, intercept first).
+    #[serde(default)]
+    pub t_statistics: Vec<T>,
+    /// Two-sided p-value of each coefficient (Student-t, `n − p − 1` df).
+    #[serde(default)]
+    pub p_values: Vec<f64>,
+    /// Global F-statistic of the regression (H₀: all slopes are zero).
+    #[serde(default)]
+    pub f_statistic: f64,
+    /// p-value of the global F-test.
+    #[serde(default)]
+    pub f_p_value: f64,
 }
 
 impl<T> Default for MultipleLinearRegression<T>
@@ -50,6 +67,11 @@ where
             standard_error: T::zero(),
             n: 0,
             p: 0,
+            coefficient_std_errors: Vec::new(),
+            t_statistics: Vec::new(),
+            p_values: Vec::new(),
+            f_statistic: 0.0,
+            f_p_value: 0.0,
         }
     }
 
@@ -194,15 +216,65 @@ where
             }
         }
 
-        // Calculate standard error
+        // Calculate standard error + per-coefficient inference
+        self.coefficient_std_errors.clear();
+        self.t_statistics.clear();
+        self.p_values.clear();
+        self.f_statistic = 0.0;
+        self.f_p_value = 0.0;
         if self.n > self.p + 1 {
-            let n_minus_p_minus_1 = T::from(self.n - self.p - 1).ok_or_else(|| {
-                StatsError::conversion_error(format!(
-                    "Failed to convert {} to type T",
-                    self.n - self.p - 1
-                ))
+            let df = self.n - self.p - 1;
+            let n_minus_p_minus_1 = T::from(df).ok_or_else(|| {
+                StatsError::conversion_error(format!("Failed to convert {df} to type T"))
             })?;
             self.standard_error = (ss_residual / n_minus_p_minus_1).sqrt();
+
+            // Per-coefficient SE via the diagonal of (XᵀX)⁻¹ — xt_x is
+            // already built. Singularity here is not fatal (the system was
+            // solvable); inference fields just stay empty.
+            let xtx_f64: Option<Vec<f64>> = xt_x.iter().map(|v| v.to_f64()).collect();
+            let s2 = ss_residual.to_f64().unwrap_or(f64::NAN) / df as f64;
+            if let Some(xtx_f64) = xtx_f64
+                && let Ok(inv) = crate::utils::linalg::invert(&xtx_f64, m, 1e-12)
+            {
+                let dff = df as f64;
+                for j in 0..m {
+                    let se = (s2 * inv[j * m + j]).max(0.0).sqrt();
+                    let beta = self.coefficients[j].to_f64().unwrap_or(f64::NAN);
+                    let t = beta / se;
+                    // Two-sided Student-t p-value: I_{df/(df+t²)}(df/2, ½).
+                    let p_val = crate::utils::special_functions::regularized_incomplete_beta(
+                        0.5 * dff,
+                        0.5,
+                        dff / (dff + t * t),
+                    )
+                    .clamp(0.0, 1.0);
+                    self.coefficient_std_errors.push(
+                        T::from(se).ok_or_else(|| {
+                            StatsError::conversion_error("Failed to convert SE to type T")
+                        })?,
+                    );
+                    self.t_statistics.push(T::from(t).ok_or_else(|| {
+                        StatsError::conversion_error("Failed to convert t to type T")
+                    })?);
+                    self.p_values.push(p_val);
+                }
+            }
+
+            // Global F-test: F = ((SS_tot − SS_res)/p) / (SS_res/(n−p−1)).
+            let ss_tot = ss_total.to_f64().unwrap_or(f64::NAN);
+            let ss_res = ss_residual.to_f64().unwrap_or(f64::NAN);
+            if self.p > 0 && ss_res > 0.0 && ss_tot > ss_res {
+                let f = ((ss_tot - ss_res) / self.p as f64) / (ss_res / df as f64);
+                self.f_statistic = f;
+                use crate::distributions::traits::Distribution as _;
+                if let Ok(fd) = crate::distributions::f_distribution::FDistribution::new(
+                    self.p as f64,
+                    df as f64,
+                ) {
+                    self.f_p_value = fd.sf(f).map(|p| p.clamp(0.0, 1.0)).unwrap_or(f64::NAN);
+                }
+            }
         }
 
         Ok(())

--- a/src/regression/multiple_linear_regression.rs
+++ b/src/regression/multiple_linear_regression.rs
@@ -12,6 +12,11 @@ use std::io::{self};
 #[cfg(feature = "serde")]
 use std::path::Path;
 
+#[cfg(feature = "serde")]
+fn nan_default() -> f64 {
+    f64::NAN
+}
+
 /// Multiple linear regression model that fits a hyperplane to multivariate data points.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -42,11 +47,13 @@ where
     /// Two-sided p-value of each coefficient (Student-t, `n − p − 1` df).
     #[cfg_attr(feature = "serde", serde(default))]
     pub p_values: Vec<f64>,
-    /// Global F-statistic of the regression (H₀: all slopes are zero).
-    #[cfg_attr(feature = "serde", serde(default))]
+    /// Global F-statistic of the regression (H₀: all slopes are zero);
+    /// `NaN` when the test is not computable (n ≤ p+1, zero residuals…).
+    #[cfg_attr(feature = "serde", serde(default = "nan_default"))]
     pub f_statistic: f64,
-    /// p-value of the global F-test.
-    #[cfg_attr(feature = "serde", serde(default))]
+    /// p-value of the global F-test; `NaN` when not computable — a 0.0
+    /// sentinel would read as "infinitely significant".
+    #[cfg_attr(feature = "serde", serde(default = "nan_default"))]
     pub f_p_value: f64,
 }
 
@@ -75,8 +82,8 @@ where
             coefficient_std_errors: Vec::new(),
             t_statistics: Vec::new(),
             p_values: Vec::new(),
-            f_statistic: 0.0,
-            f_p_value: 0.0,
+            f_statistic: f64::NAN,
+            f_p_value: f64::NAN,
         }
     }
 
@@ -225,8 +232,8 @@ where
         self.coefficient_std_errors.clear();
         self.t_statistics.clear();
         self.p_values.clear();
-        self.f_statistic = 0.0;
-        self.f_p_value = 0.0;
+        self.f_statistic = f64::NAN;
+        self.f_p_value = f64::NAN;
         if self.n > self.p + 1 {
             let df = self.n - self.p - 1;
             let n_minus_p_minus_1 = T::from(df).ok_or_else(|| {

--- a/src/regression/multiple_linear_regression.rs
+++ b/src/regression/multiple_linear_regression.rs
@@ -2,17 +2,22 @@
 
 use crate::error::{StatsError, StatsResult};
 use num_traits::{Float, NumCast};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+#[cfg(feature = "serde")]
 use std::fs::File;
+#[cfg(feature = "serde")]
 use std::io::{self};
+#[cfg(feature = "serde")]
 use std::path::Path;
 
 /// Multiple linear regression model that fits a hyperplane to multivariate data points.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultipleLinearRegression<T = f64>
 where
-    T: Float + Debug + Default + Serialize,
+    T: Float + Debug + Default,
 {
     /// Regression coefficients, including intercept as the first element
     pub coefficients: Vec<T>,
@@ -29,25 +34,25 @@ where
     /// Standard error of each coefficient (intercept first):
     /// `SE(βⱼ) = s·√[(XᵀX)⁻¹]ⱼⱼ`. Empty if `n ≤ p + 1` or `XᵀX` is singular.
     /// `#[serde(default)]` keeps pre-v3.1 saved models loadable.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub coefficient_std_errors: Vec<T>,
     /// t-statistic of each coefficient (`βⱼ / SE(βⱼ)`, intercept first).
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub t_statistics: Vec<T>,
     /// Two-sided p-value of each coefficient (Student-t, `n − p − 1` df).
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub p_values: Vec<f64>,
     /// Global F-statistic of the regression (H₀: all slopes are zero).
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub f_statistic: f64,
     /// p-value of the global F-test.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub f_p_value: f64,
 }
 
 impl<T> Default for MultipleLinearRegression<T>
 where
-    T: Float + Debug + Default + NumCast + Serialize + for<'de> Deserialize<'de>,
+    T: Float + Debug + Default + NumCast,
 {
     fn default() -> Self {
         Self::new()
@@ -56,7 +61,7 @@ where
 
 impl<T> MultipleLinearRegression<T>
 where
-    T: Float + Debug + Default + NumCast + Serialize + for<'de> Deserialize<'de>,
+    T: Float + Debug + Default + NumCast,
 {
     /// Create a new multiple linear regression model without fitting any data
     pub fn new() -> Self {
@@ -397,6 +402,14 @@ where
         x_values.iter().map(|x| self.predict(x)).collect()
     }
 
+}
+
+/// Model persistence — requires the `serde` feature.
+#[cfg(feature = "serde")]
+impl<T> MultipleLinearRegression<T>
+where
+    T: Float + Debug + Default + NumCast + Serialize + for<'de> Deserialize<'de>,
+{
     /// Save the model to a file
     ///
     /// # Arguments
@@ -585,6 +598,7 @@ where
 mod tests {
     use super::*;
     use crate::utils::approx_equal;
+    #[cfg(feature = "serde")]
     use tempfile::tempdir;
 
     #[test]
@@ -686,6 +700,7 @@ mod tests {
         assert!(approx_equal(predictions[1], 23.0, Some(1e-6)));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_save_load_json() {
         // Create a temporary directory
@@ -727,6 +742,7 @@ mod tests {
         assert_eq!(loaded.p, model.p);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_save_load_binary() {
         // Create a temporary directory
@@ -768,6 +784,7 @@ mod tests {
         assert_eq!(loaded.p, model.p);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_json_serialization() {
         // Create and fit a model
@@ -871,6 +888,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_save_invalid_path() {
         // Test saving to an invalid path
@@ -887,6 +905,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_load_nonexistent_file() {
         // Test loading a non-existent file
@@ -898,6 +917,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_from_json_invalid() {
         // Test deserializing invalid JSON string

--- a/src/resampling.rs
+++ b/src/resampling.rs
@@ -47,9 +47,10 @@ fn index(rng: &mut dyn RngCore, n: usize) -> usize {
 ///
 /// Resamples `data` with replacement `n_resamples` times, evaluates
 /// `statistic` on each replicate, and returns the empirical
-/// `(1−level)/2` and `(1+level)/2` quantiles of the replicates (the
-/// *percentile* method — same default flavour as `scipy.stats.bootstrap`
-/// offers). Prefer ≥ 2000 resamples for a 95% interval.
+/// `(1−level)/2` and `(1+level)/2` quantiles of the replicates — the
+/// *percentile* method (one of `scipy.stats.bootstrap`'s methods; note
+/// scipy defaults to the BCa variant, which corrects for bias and
+/// skewness). Prefer ≥ 2000 resamples for a 95% interval.
 ///
 /// # Errors
 /// Returns an error on empty data, `n_resamples < 100`, or `level`

--- a/src/resampling.rs
+++ b/src/resampling.rs
@@ -1,0 +1,331 @@
+//! # Resampling: bootstrap confidence intervals & permutation tests
+//!
+//! Distribution-free inference for **any** statistic — no normality
+//! assumption, no closed-form standard error needed. Pass a closure, get
+//! an interval or a p-value.
+//!
+//! ```
+//! use rs_stats::resampling::bootstrap_ci;
+//! use rs_stats::prob::quantile;
+//! use rand::SeedableRng;
+//!
+//! let data = [12.1, 14.8, 15.2, 17.9, 19.3, 22.4, 25.1, 28.7, 33.0, 41.2,
+//!             48.9, 55.3, 71.8, 13.4, 16.0, 18.2, 12.9, 14.1, 96.5, 24.6];
+//! let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+//! // 95% CI for the MEDIAN — no formula exists; the bootstrap doesn't care.
+//! let ci = bootstrap_ci(&data, |s| quantile(s, 0.5).unwrap(), 2000, 0.95, &mut rng).unwrap();
+//! assert!(ci.lower < ci.estimate && ci.estimate < ci.upper);
+//! ```
+
+use crate::error::{StatsError, StatsResult};
+use crate::hypothesis_tests::Alternative;
+use rand::RngCore;
+
+/// Result of [`bootstrap_ci`].
+#[derive(Debug, Clone, Copy)]
+pub struct BootstrapCi {
+    /// The statistic evaluated on the original data.
+    pub estimate: f64,
+    /// Lower bound of the percentile confidence interval.
+    pub lower: f64,
+    /// Upper bound of the percentile confidence interval.
+    pub upper: f64,
+    /// Bootstrap standard error (sample std-dev of the replicates).
+    pub std_error: f64,
+    /// Number of resamples actually used.
+    pub n_resamples: usize,
+}
+
+/// Draw an index in `[0, n)` from the top 53 bits of a `u64`.
+/// The modulo bias is ~n/2⁵³ — irrelevant for any realistic n.
+#[inline]
+fn index(rng: &mut dyn RngCore, n: usize) -> usize {
+    ((rng.next_u64() >> 11) as usize) % n
+}
+
+/// Percentile-bootstrap confidence interval for an arbitrary statistic.
+///
+/// Resamples `data` with replacement `n_resamples` times, evaluates
+/// `statistic` on each replicate, and returns the empirical
+/// `(1−level)/2` and `(1+level)/2` quantiles of the replicates (the
+/// *percentile* method — same default flavour as `scipy.stats.bootstrap`
+/// offers). Prefer ≥ 2000 resamples for a 95% interval.
+///
+/// # Errors
+/// Returns an error on empty data, `n_resamples < 100`, or `level`
+/// outside (0, 1).
+pub fn bootstrap_ci(
+    data: &[f64],
+    statistic: impl Fn(&[f64]) -> f64,
+    n_resamples: usize,
+    level: f64,
+    rng: &mut dyn RngCore,
+) -> StatsResult<BootstrapCi> {
+    if data.is_empty() {
+        return Err(StatsError::empty_data(
+            "bootstrap_ci: data must not be empty",
+        ));
+    }
+    if n_resamples < 100 {
+        return Err(StatsError::invalid_parameter(format!(
+            "bootstrap_ci: n_resamples must be ≥ 100, got {n_resamples}"
+        )));
+    }
+    if !(0.0 < level && level < 1.0) {
+        return Err(StatsError::invalid_parameter(format!(
+            "bootstrap_ci: level must be in (0, 1), got {level}"
+        )));
+    }
+
+    let n = data.len();
+    let estimate = statistic(data);
+
+    let mut scratch = vec![0.0_f64; n];
+    let mut replicates = Vec::with_capacity(n_resamples);
+    for _ in 0..n_resamples {
+        for slot in scratch.iter_mut() {
+            *slot = data[index(rng, n)];
+        }
+        replicates.push(statistic(&scratch));
+    }
+
+    let mean = replicates.iter().sum::<f64>() / n_resamples as f64;
+    let var = replicates
+        .iter()
+        .map(|r| (r - mean) * (r - mean))
+        .sum::<f64>()
+        / (n_resamples - 1) as f64;
+
+    replicates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let q = |p: f64| {
+        let h = (n_resamples - 1) as f64 * p;
+        let lo = h.floor() as usize;
+        let hi = h.ceil() as usize;
+        replicates[lo] + (h - lo as f64) * (replicates[hi] - replicates[lo])
+    };
+    let alpha = (1.0 - level) / 2.0;
+
+    Ok(BootstrapCi {
+        estimate,
+        lower: q(alpha),
+        upper: q(1.0 - alpha),
+        std_error: var.sqrt(),
+        n_resamples,
+    })
+}
+
+/// Result of [`permutation_test`].
+#[derive(Debug, Clone, Copy)]
+pub struct PermutationTest {
+    /// The statistic on the original (unpermuted) samples.
+    pub statistic: f64,
+    /// Monte-Carlo p-value, `(1 + #extreme) / (n_permutations + 1)`.
+    pub p_value: f64,
+    /// Number of random permutations drawn.
+    pub n_permutations: usize,
+}
+
+/// Two-sample permutation test for an arbitrary statistic.
+///
+/// Under H₀ ("the two samples come from the same distribution"), group
+/// labels are exchangeable: the pooled values are reshuffled
+/// `n_permutations` times and `statistic(a', b')` recomputed on each
+/// split. The p-value uses the add-one estimator
+/// `(1 + #extreme)/(B + 1)`, which is never exactly 0.
+///
+/// [`Alternative::TwoSided`] compares `|statistic|`, so it assumes the
+/// statistic is centred at 0 under H₀ (e.g. a difference of means or
+/// medians). `Greater` / `Less` compare the signed value.
+///
+/// # Examples
+/// ```
+/// use rs_stats::resampling::permutation_test;
+/// use rs_stats::hypothesis_tests::Alternative;
+/// use rand::SeedableRng;
+///
+/// let a = [1.2, 1.5, 1.1, 1.8, 1.3, 1.6, 1.4, 1.7];
+/// let b = [2.4, 2.1, 2.8, 2.3, 2.6, 2.2, 2.7, 2.5];
+/// let mean = |s: &[f64]| s.iter().sum::<f64>() / s.len() as f64;
+/// let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(7);
+/// let r = permutation_test(&a, &b, |x, y| mean(x) - mean(y), 9999,
+///                          Alternative::TwoSided, &mut rng).unwrap();
+/// assert!(r.p_value < 0.001);
+/// ```
+pub fn permutation_test(
+    a: &[f64],
+    b: &[f64],
+    statistic: impl Fn(&[f64], &[f64]) -> f64,
+    n_permutations: usize,
+    alternative: Alternative,
+    rng: &mut dyn RngCore,
+) -> StatsResult<PermutationTest> {
+    if a.is_empty() || b.is_empty() {
+        return Err(StatsError::invalid_input(
+            "permutation_test: both samples must be non-empty",
+        ));
+    }
+    if n_permutations < 100 {
+        return Err(StatsError::invalid_parameter(format!(
+            "permutation_test: n_permutations must be ≥ 100, got {n_permutations}"
+        )));
+    }
+
+    let observed = statistic(a, b);
+    let n_a = a.len();
+    let mut pool: Vec<f64> = a.iter().chain(b.iter()).copied().collect();
+    let n = pool.len();
+
+    // Relative slack against ties lost to floating-point noise (as scipy).
+    let gamma = 1e-14 * observed.abs().max(1.0);
+    let mut extreme = 0usize;
+    for _ in 0..n_permutations {
+        // Partial Fisher-Yates: after n_a swaps, pool[..n_a] is a uniform
+        // random subset in random order — exactly a label permutation.
+        for i in 0..n_a {
+            let j = i + index(rng, n - i);
+            pool.swap(i, j);
+        }
+        let t = statistic(&pool[..n_a], &pool[n_a..]);
+        let hit = match alternative {
+            Alternative::TwoSided => t.abs() >= observed.abs() - gamma,
+            Alternative::Greater => t >= observed - gamma,
+            Alternative::Less => t <= observed + gamma,
+        };
+        if hit {
+            extreme += 1;
+        }
+    }
+
+    Ok(PermutationTest {
+        statistic: observed,
+        p_value: (1 + extreme) as f64 / (n_permutations + 1) as f64,
+        n_permutations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    fn mean(s: &[f64]) -> f64 {
+        s.iter().sum::<f64>() / s.len() as f64
+    }
+
+    #[test]
+    fn test_bootstrap_mean_ci_matches_t_interval() {
+        // For the sample mean, the percentile bootstrap must approximate
+        // the classical t-interval.
+        let data: Vec<f64> = (0..60)
+            .map(|i| 10.0 + ((i * 37) % 17) as f64 * 0.5)
+            .collect();
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let ci = bootstrap_ci(&data, mean, 5000, 0.95, &mut rng).unwrap();
+
+        let m = mean(&data);
+        let sd = (data.iter().map(|x| (x - m) * (x - m)).sum::<f64>() / 59.0).sqrt();
+        let se = sd / (60.0_f64).sqrt();
+        assert!((ci.estimate - m).abs() < 1e-12);
+        assert!(
+            (ci.lower - (m - 2.0 * se)).abs() < 0.5,
+            "lower = {}",
+            ci.lower
+        );
+        assert!(
+            (ci.upper - (m + 2.0 * se)).abs() < 0.5,
+            "upper = {}",
+            ci.upper
+        );
+        assert!((ci.std_error - se).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_bootstrap_deterministic_with_seed() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut r1 = ChaCha8Rng::seed_from_u64(5);
+        let mut r2 = ChaCha8Rng::seed_from_u64(5);
+        let c1 = bootstrap_ci(&data, mean, 1000, 0.9, &mut r1).unwrap();
+        let c2 = bootstrap_ci(&data, mean, 1000, 0.9, &mut r2).unwrap();
+        assert_eq!(c1.lower, c2.lower);
+        assert_eq!(c1.upper, c2.upper);
+    }
+
+    #[test]
+    fn test_permutation_detects_shift_and_respects_null() {
+        let mut rng = ChaCha8Rng::seed_from_u64(11);
+        let a: Vec<f64> = (0..25).map(|i| ((i * 13) % 7) as f64).collect();
+        let b_shifted: Vec<f64> = a.iter().map(|x| x + 4.0).collect();
+        let r = permutation_test(
+            &a,
+            &b_shifted,
+            |x, y| mean(x) - mean(y),
+            999,
+            Alternative::TwoSided,
+            &mut rng,
+        )
+        .unwrap();
+        assert!(r.p_value < 0.01, "p = {}", r.p_value);
+
+        // Same distribution: p must be non-significant.
+        let b_same: Vec<f64> = (0..25).map(|i| ((i * 5 + 3) % 7) as f64).collect();
+        let r = permutation_test(
+            &a,
+            &b_same,
+            |x, y| mean(x) - mean(y),
+            999,
+            Alternative::TwoSided,
+            &mut rng,
+        )
+        .unwrap();
+        assert!(r.p_value > 0.05, "p = {}", r.p_value);
+    }
+
+    #[test]
+    fn test_permutation_one_sided_consistency() {
+        // a clearly below b: Less significant, Greater not.
+        let a = [1.0, 1.2, 0.9, 1.1, 1.3, 0.8, 1.05, 1.15];
+        let b = [2.0, 2.2, 1.9, 2.1, 2.3, 1.8, 2.05, 2.15];
+        let mut rng = ChaCha8Rng::seed_from_u64(3);
+        let less = permutation_test(
+            &a,
+            &b,
+            |x, y| mean(x) - mean(y),
+            1999,
+            Alternative::Less,
+            &mut rng,
+        )
+        .unwrap();
+        let mut rng = ChaCha8Rng::seed_from_u64(3);
+        let greater = permutation_test(
+            &a,
+            &b,
+            |x, y| mean(x) - mean(y),
+            1999,
+            Alternative::Greater,
+            &mut rng,
+        )
+        .unwrap();
+        assert!(less.p_value < 0.01);
+        assert!(greater.p_value > 0.99);
+    }
+
+    #[test]
+    fn test_errors() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        assert!(bootstrap_ci(&[], mean, 1000, 0.95, &mut rng).is_err());
+        assert!(bootstrap_ci(&[1.0], mean, 50, 0.95, &mut rng).is_err());
+        assert!(bootstrap_ci(&[1.0], mean, 1000, 1.5, &mut rng).is_err());
+        assert!(
+            permutation_test(
+                &[],
+                &[1.0],
+                |_, _| 0.0,
+                999,
+                Alternative::TwoSided,
+                &mut rng
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/utils/combinatorics.rs
+++ b/src/utils/combinatorics.rs
@@ -106,6 +106,12 @@ pub fn ln_permutation(n: u64, k: u64) -> StatsResult<f64> {
             k, n
         )));
     }
+    // Direct log-sum for small k: the lnΓ difference cancels
+    // catastrophically when n ≫ k (both terms ~n·ln n; at n = 1e15 the
+    // difference keeps almost no significant bits).
+    if k <= 64 {
+        return Ok(((n - k + 1)..=n).map(|i| (i as f64).ln()).sum());
+    }
     Ok(ln_gamma(n as f64 + 1.0) - ln_gamma((n - k) as f64 + 1.0))
 }
 
@@ -182,6 +188,13 @@ pub fn ln_combination(n: u64, k: u64) -> StatsResult<f64> {
             "k ({}) cannot be greater than n ({})",
             k, n
         )));
+    }
+    // Same small-k shortcut as ln_permutation, via C(n,k) = P(n,k')/k'!
+    // with k' = min(k, n−k).
+    let k_small = k.min(n - k);
+    if k_small <= 64 {
+        let ln_perm: f64 = ((n - k_small + 1)..=n).map(|i| (i as f64).ln()).sum();
+        return Ok(ln_perm - ln_gamma(k_small as f64 + 1.0));
     }
     Ok(ln_gamma(n as f64 + 1.0) - ln_gamma(k as f64 + 1.0) - ln_gamma((n - k) as f64 + 1.0))
 }

--- a/src/utils/combinatorics.rs
+++ b/src/utils/combinatorics.rs
@@ -1,6 +1,7 @@
 //! Provides functions for combinatorial calculations.
 
 use crate::error::{StatsError, StatsResult};
+use crate::utils::special_functions::ln_gamma;
 
 /// Calculate the factorial of a number n.
 ///
@@ -46,10 +47,12 @@ pub fn factorial(n: u64) -> StatsResult<u64> {
 /// * `k` - The number of items to choose.
 ///
 /// # Returns
-/// * `StatsResult<u64>` - The number of permutations, or an error if k > n.
+/// * `StatsResult<u64>` - The number of permutations, or an error if k > n
+///   or the result overflows `u64`.
 ///
 /// # Errors
-/// Returns `StatsError::InvalidInput` if `k > n`.
+/// Returns `StatsError::InvalidInput` if `k > n`, or if the result overflows
+/// `u64` (use [`ln_permutation`] for large arguments).
 ///
 /// # Examples
 /// ```
@@ -58,8 +61,9 @@ pub fn factorial(n: u64) -> StatsResult<u64> {
 /// let result = permutation(5, 3).unwrap();
 /// assert_eq!(result, 60);
 ///
-/// // Error case
+/// // Error cases
 /// assert!(permutation(5, 10).is_err());
+/// assert!(permutation(30, 20).is_err()); // overflows u64
 /// ```
 pub fn permutation(n: u64, k: u64) -> StatsResult<u64> {
     if k > n {
@@ -68,7 +72,41 @@ pub fn permutation(n: u64, k: u64) -> StatsResult<u64> {
             k, n
         )));
     }
-    Ok(((n - k + 1)..=n).product::<u64>())
+    let mut result: u64 = 1;
+    for i in (n - k + 1)..=n {
+        result = result.checked_mul(i).ok_or_else(|| {
+            StatsError::invalid_input(format!(
+                "permutation({n}, {k}) overflows u64; use ln_permutation for large arguments"
+            ))
+        })?;
+    }
+    Ok(result)
+}
+
+/// Natural logarithm of the number of permutations:
+/// `ln P(n, k) = ln Γ(n+1) − ln Γ(n−k+1)`.
+///
+/// Never overflows — use this when [`permutation`] exceeds `u64`.
+///
+/// # Errors
+/// Returns `StatsError::InvalidInput` if `k > n`.
+///
+/// # Examples
+/// ```
+/// use rs_stats::utils::combinatorics::{ln_permutation, permutation};
+///
+/// let exact = permutation(10, 3).unwrap() as f64;
+/// let ln = ln_permutation(10, 3).unwrap();
+/// assert!((ln - exact.ln()).abs() < 1e-10);
+/// ```
+pub fn ln_permutation(n: u64, k: u64) -> StatsResult<f64> {
+    if k > n {
+        return Err(StatsError::invalid_input(format!(
+            "k ({}) cannot be greater than n ({})",
+            k, n
+        )));
+    }
+    Ok(ln_gamma(n as f64 + 1.0) - ln_gamma((n - k) as f64 + 1.0))
 }
 
 /// Calculate the number of combinations of n items taken k at a time.
@@ -78,10 +116,12 @@ pub fn permutation(n: u64, k: u64) -> StatsResult<u64> {
 /// * `k` - The number of items to choose.
 ///
 /// # Returns
-/// * `StatsResult<u64>` - The number of combinations, or an error if k > n.
+/// * `StatsResult<u64>` - The number of combinations, or an error if k > n
+///   or the result overflows `u64`.
 ///
 /// # Errors
-/// Returns `StatsError::InvalidInput` if `k > n`.
+/// Returns `StatsError::InvalidInput` if `k > n`, or if the result overflows
+/// `u64` (use [`ln_combination`] for large arguments).
 ///
 /// # Examples
 /// ```
@@ -90,8 +130,12 @@ pub fn permutation(n: u64, k: u64) -> StatsResult<u64> {
 /// let result = combination(5, 3).unwrap();
 /// assert_eq!(result, 10);
 ///
-/// // Error case
+/// // C(66, 33) fits in u64 even though naive intermediates overflow.
+/// assert_eq!(combination(66, 33).unwrap(), 7_219_428_434_016_265_740);
+///
+/// // Error cases
 /// assert!(combination(5, 10).is_err());
+/// assert!(combination(70, 35).is_err()); // overflows u64
 /// ```
 pub fn combination(n: u64, k: u64) -> StatsResult<u64> {
     if k > n {
@@ -101,7 +145,45 @@ pub fn combination(n: u64, k: u64) -> StatsResult<u64> {
         )));
     }
     let k = if k > n - k { n - k } else { k };
-    Ok((1..=k).fold(1, |acc, x| acc * (n - x + 1) / x))
+    // Intermediates are held in u128: after step x the accumulator equals
+    // C(n, x), but the product before the division is C(n, x)·x, which can
+    // overflow u64 even when the final C(n, k) fits (e.g. C(66, 33)).
+    let overflow = || {
+        StatsError::invalid_input(format!(
+            "combination({n}, {k}) overflows u64; use ln_combination for large arguments"
+        ))
+    };
+    let mut acc: u128 = 1;
+    for x in 1..=k {
+        acc = acc.checked_mul((n - x + 1) as u128).ok_or_else(overflow)? / (x as u128);
+    }
+    u64::try_from(acc).map_err(|_| overflow())
+}
+
+/// Natural logarithm of the number of combinations:
+/// `ln C(n, k) = ln Γ(n+1) − ln Γ(k+1) − ln Γ(n−k+1)`.
+///
+/// Never overflows — use this when [`combination`] exceeds `u64`.
+///
+/// # Errors
+/// Returns `StatsError::InvalidInput` if `k > n`.
+///
+/// # Examples
+/// ```
+/// use rs_stats::utils::combinatorics::{combination, ln_combination};
+///
+/// let exact = combination(10, 3).unwrap() as f64;
+/// let ln = ln_combination(10, 3).unwrap();
+/// assert!((ln - exact.ln()).abs() < 1e-10);
+/// ```
+pub fn ln_combination(n: u64, k: u64) -> StatsResult<f64> {
+    if k > n {
+        return Err(StatsError::invalid_input(format!(
+            "k ({}) cannot be greater than n ({})",
+            k, n
+        )));
+    }
+    Ok(ln_gamma(n as f64 + 1.0) - ln_gamma(k as f64 + 1.0) - ln_gamma((n - k) as f64 + 1.0))
 }
 
 #[cfg(test)]
@@ -159,6 +241,38 @@ mod tests {
             combination(5, 10).unwrap_err(),
             StatsError::InvalidInput { .. }
         ));
+    }
+
+    #[test]
+    fn test_permutation_overflow() {
+        // P(30, 20) = 30!/10! ≈ 7.3e25 > u64::MAX — must error, never wrap.
+        assert!(permutation(30, 20).is_err());
+        // P(20, 10) fits.
+        assert_eq!(permutation(20, 10).unwrap(), 670_442_572_800);
+    }
+
+    #[test]
+    fn test_combination_u64_edge() {
+        // Fits in u64 but naive u64 intermediates overflow.
+        assert_eq!(combination(66, 33).unwrap(), 7_219_428_434_016_265_740);
+        assert_eq!(combination(62, 31).unwrap(), 465_428_353_255_261_088);
+        // Result itself exceeds u64 — typed error.
+        assert!(combination(70, 35).is_err());
+    }
+
+    #[test]
+    fn test_ln_variants() {
+        // Agree with exact values where those exist…
+        let exact = combination(52, 5).unwrap() as f64;
+        assert!((ln_combination(52, 5).unwrap() - exact.ln()).abs() < 1e-9);
+        let exact = permutation(20, 10).unwrap() as f64;
+        assert!((ln_permutation(20, 10).unwrap() - exact.ln()).abs() < 1e-9);
+        // …and stay finite far beyond u64 range.
+        assert!(ln_combination(1000, 500).unwrap().is_finite());
+        assert!(ln_permutation(1000, 500).unwrap().is_finite());
+        // Same domain validation as the exact versions.
+        assert!(ln_combination(5, 10).is_err());
+        assert!(ln_permutation(5, 10).is_err());
     }
 
     #[test]

--- a/src/utils/linalg.rs
+++ b/src/utils/linalg.rs
@@ -122,6 +122,48 @@ pub fn invert_with_ridge(matrix: &[f64], dim: usize, ridge_factor: f64) -> Stats
     invert_augmented(aug, dim, 1e-9)
 }
 
+/// Cholesky decomposition of a symmetric positive-definite matrix
+/// (row-major, `dim × dim`): returns the lower-triangular `L` with
+/// `A = L·Lᵀ` (upper triangle of the result is zero).
+///
+/// Also the standard SPD test: a covariance matrix is valid iff this
+/// succeeds.
+///
+/// # Errors
+/// Returns an error on a size mismatch, or when the matrix is not
+/// positive-definite (a pivot ≤ 0 within tolerance).
+pub fn cholesky(matrix: &[f64], dim: usize) -> StatsResult<Vec<f64>> {
+    if matrix.len() != dim * dim {
+        return Err(StatsError::invalid_input(format!(
+            "linalg::cholesky: expected {} elements for {}×{} matrix, got {}",
+            dim * dim,
+            dim,
+            dim,
+            matrix.len()
+        )));
+    }
+    let mut l = vec![0.0_f64; dim * dim];
+    for i in 0..dim {
+        for j in 0..=i {
+            let mut sum = matrix[i * dim + j];
+            for k in 0..j {
+                sum -= l[i * dim + k] * l[j * dim + k];
+            }
+            if i == j {
+                if sum <= 0.0 {
+                    return Err(StatsError::numerical_error(format!(
+                        "linalg::cholesky: matrix is not positive-definite (pivot {sum:.3e} at row {i})"
+                    )));
+                }
+                l[i * dim + j] = sum.sqrt();
+            } else {
+                l[i * dim + j] = sum / l[j * dim + j];
+            }
+        }
+    }
+    Ok(l)
+}
+
 /// Gauss-Jordan elimination on a pre-built `[A | I]` augmented matrix of shape
 /// `dim × (2·dim)`. Shared between [`invert`] and [`invert_with_ridge`].
 fn invert_augmented(mut aug: Vec<f64>, dim: usize, eps: f64) -> StatsResult<Vec<f64>> {

--- a/src/utils/linalg.rs
+++ b/src/utils/linalg.rs
@@ -150,7 +150,8 @@ pub fn cholesky(matrix: &[f64], dim: usize) -> StatsResult<Vec<f64>> {
                 sum -= l[i * dim + k] * l[j * dim + k];
             }
             if i == j {
-                if sum <= 0.0 {
+                // `!(sum > 0.0)` also rejects a NaN pivot (NaN ≤ 0 is false).
+                if !(sum > 0.0) {
                     return Err(StatsError::numerical_error(format!(
                         "linalg::cholesky: matrix is not positive-definite (pivot {sum:.3e} at row {i})"
                     )));

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,7 +10,7 @@ pub use self::combinatorics::{
 };
 pub use self::constants::{E, INV_SQRT_2PI, LN_2PI, PI, SQRT_2, SQRT_2PI};
 pub use self::linalg::{invert, invert_with_ridge, mahalanobis_sq, mahalanobis_sq_into};
-pub use self::numeric::{approx_equal, safe_log};
+pub use self::numeric::{approx_equal, average_ranks, safe_log};
 pub use self::special_functions::{
     beta_fn, bisect_inverse_cdf, gamma_fn, ln_beta, ln_gamma, regularized_incomplete_beta,
     regularized_incomplete_gamma, regularized_incomplete_gamma_upper,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,11 +5,13 @@ pub mod linalg;
 pub mod numeric;
 pub mod special_functions;
 
-pub use self::combinatorics::{combination, factorial, permutation};
+pub use self::combinatorics::{
+    combination, factorial, ln_combination, ln_permutation, permutation,
+};
 pub use self::constants::{E, INV_SQRT_2PI, LN_2PI, PI, SQRT_2, SQRT_2PI};
-pub use self::linalg::{invert, invert_with_ridge, mahalanobis_sq};
+pub use self::linalg::{invert, invert_with_ridge, mahalanobis_sq, mahalanobis_sq_into};
 pub use self::numeric::{approx_equal, safe_log};
 pub use self::special_functions::{
     beta_fn, bisect_inverse_cdf, gamma_fn, ln_beta, ln_gamma, regularized_incomplete_beta,
-    regularized_incomplete_gamma,
+    regularized_incomplete_gamma, regularized_incomplete_gamma_upper,
 };

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,7 @@ pub use self::combinatorics::{
     combination, factorial, ln_combination, ln_permutation, permutation,
 };
 pub use self::constants::{E, INV_SQRT_2PI, LN_2PI, PI, SQRT_2, SQRT_2PI};
-pub use self::linalg::{invert, invert_with_ridge, mahalanobis_sq, mahalanobis_sq_into};
+pub use self::linalg::{cholesky, invert, invert_with_ridge, mahalanobis_sq, mahalanobis_sq_into};
 pub use self::numeric::{approx_equal, average_ranks, safe_log};
 pub use self::special_functions::{
     beta_fn, bisect_inverse_cdf, gamma_fn, ln_beta, ln_gamma, regularized_incomplete_beta,

--- a/src/utils/numeric.rs
+++ b/src/utils/numeric.rs
@@ -111,11 +111,9 @@ where
 pub fn average_ranks(values: &[f64]) -> Vec<f64> {
     let n = values.len();
     let mut order: Vec<usize> = (0..n).collect();
-    order.sort_by(|&a, &b| {
-        values[a]
-            .partial_cmp(&values[b])
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    // total_cmp: NaNs sort deterministically to the end instead of
+    // corrupting the order of the finite elements.
+    order.sort_by(|&a, &b| values[a].total_cmp(&values[b]));
 
     let mut ranks = vec![0.0_f64; n];
     let mut i = 0;

--- a/src/utils/numeric.rs
+++ b/src/utils/numeric.rs
@@ -97,6 +97,44 @@ where
     approx_equal(a, b, None)
 }
 
+/// 1-based **average ranks** of `values` (ties get the mean of the ranks
+/// they span) — the convention used by Spearman correlation and the
+/// rank-based tests (Mann-Whitney U, Wilcoxon signed-rank).
+///
+/// # Examples
+/// ```
+/// use rs_stats::utils::numeric::average_ranks;
+///
+/// let r = average_ranks(&[10.0, 20.0, 20.0, 30.0]);
+/// assert_eq!(r, vec![1.0, 2.5, 2.5, 4.0]);
+/// ```
+pub fn average_ranks(values: &[f64]) -> Vec<f64> {
+    let n = values.len();
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by(|&a, &b| {
+        values[a]
+            .partial_cmp(&values[b])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut ranks = vec![0.0_f64; n];
+    let mut i = 0;
+    while i < n {
+        // Find the tie run [i, j).
+        let mut j = i + 1;
+        while j < n && values[order[j]] == values[order[i]] {
+            j += 1;
+        }
+        // Average of 1-based ranks i+1 ..= j.
+        let avg = (i + 1 + j) as f64 / 2.0;
+        for &idx in &order[i..j] {
+            ranks[idx] = avg;
+        }
+        i = j;
+    }
+    ranks
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils/special_functions.rs
+++ b/src/utils/special_functions.rs
@@ -301,6 +301,80 @@ pub fn noncentral_t_sf(t: f64, df: f64, nc: f64) -> f64 {
     noncentral_t_cdf(-t, df, -nc)
 }
 
+// ── Inverse CDF via bracketed Newton ──────────────────────────────────────────
+
+/// Find x with `cdf_fn(x) ≈ p` using a short bisection to localise the
+/// root, then bracket-safeguarded Newton steps (`x ← x − (F(x)−p)/f(x)`).
+///
+/// Quadratic convergence cuts the CDF evaluations from ~60 (pure
+/// bisection at relative 1e-12) to ~15. Falls back to a bisection step
+/// whenever Newton leaves the bracket or the density vanishes, so it is
+/// as robust as [`bisect_inverse_cdf`] (including the same dynamic
+/// bracket expansion).
+pub fn newton_inverse_cdf(
+    cdf_fn: impl Fn(f64) -> f64,
+    pdf_fn: impl Fn(f64) -> f64,
+    p: f64,
+    mut lo: f64,
+    mut hi: f64,
+) -> f64 {
+    const EPS: f64 = 1e-12;
+
+    // Same dynamic bracket expansion as bisect_inverse_cdf.
+    let mut width = (hi - lo).abs().max(1.0);
+    for _ in 0..200 {
+        if cdf_fn(hi) >= p {
+            break;
+        }
+        lo = hi;
+        hi += width;
+        width *= 2.0;
+    }
+    let mut width = (hi - lo).abs().max(1.0);
+    for _ in 0..200 {
+        if cdf_fn(lo) <= p {
+            break;
+        }
+        hi = lo;
+        lo -= width;
+        width *= 2.0;
+    }
+
+    // A few bisection steps to give Newton a well-conditioned start.
+    for _ in 0..6 {
+        let mid = 0.5 * (lo + hi);
+        if cdf_fn(mid) < p {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    let mut x = 0.5 * (lo + hi);
+    for _ in 0..40 {
+        let f = cdf_fn(x) - p;
+        if f > 0.0 {
+            hi = x;
+        } else {
+            lo = x;
+        }
+        let d = pdf_fn(x);
+        let mut x_new = x - f / d;
+        if !x_new.is_finite() || x_new <= lo || x_new >= hi {
+            // Newton left the bracket (flat density, overshoot): bisect.
+            x_new = 0.5 * (lo + hi);
+        }
+        if (x_new - x).abs() <= EPS * x.abs().max(1.0) {
+            return x_new;
+        }
+        x = x_new;
+        if (hi - lo).abs() <= EPS * x.abs().max(1.0) {
+            return x;
+        }
+    }
+    x
+}
+
 // ── General inverse CDF via bisection ─────────────────────────────────────────
 
 /// Find x such that `cdf_fn(x) ≈ p` via bisection starting from `[lo, hi]`.

--- a/src/utils/special_functions.rs
+++ b/src/utils/special_functions.rs
@@ -70,6 +70,24 @@ pub fn regularized_incomplete_gamma(a: f64, x: f64) -> f64 {
     }
 }
 
+/// Regularized *upper* incomplete gamma function Q(a, x) = 1 − P(a, x).
+///
+/// Computed directly (series or continued fraction on the appropriate side)
+/// so tiny tail values keep full **relative** precision — `1.0 - P(a, x)`
+/// would round to 0 as soon as Q < ~1e-16. This is the primitive behind
+/// accurate tail probabilities (`erfc`, survival functions, p-values).
+pub fn regularized_incomplete_gamma_upper(a: f64, x: f64) -> f64 {
+    debug_assert!(a > 0.0, "a must be positive");
+    if x <= 0.0 {
+        return 1.0;
+    }
+    if x < a + 1.0 {
+        1.0 - gamma_series(a, x)
+    } else {
+        gamma_continued_fraction(a, x)
+    }
+}
+
 /// Series representation of the lower regularized incomplete gamma.
 /// Converges well when x < a + 1.
 fn gamma_series(a: f64, x: f64) -> f64 {
@@ -227,15 +245,42 @@ fn beta_cf(a: f64, b: f64, x: f64) -> f64 {
 
 // ── General inverse CDF via bisection ─────────────────────────────────────────
 
-/// Find x such that `cdf_fn(x) ≈ p` via bisection on `[lo, hi]`.
-/// `cdf_fn` must be monotone non-decreasing on that interval.
+/// Find x such that `cdf_fn(x) ≈ p` via bisection starting from `[lo, hi]`.
+/// `cdf_fn` must be monotone non-decreasing.
+///
+/// `[lo, hi]` is a *seed* bracket, not a hard bound: if the quantile lies
+/// outside it, the bracket is expanded geometrically until it contains `p`
+/// (heavy-tailed distributions — t with ν ≤ 2, F with small d2 — put
+/// extreme quantiles orders of magnitude beyond any moment-based guess).
+/// Bounded supports never expand: their endpoint CDF already reaches 0/1.
 pub fn bisect_inverse_cdf(cdf_fn: impl Fn(f64) -> f64, p: f64, mut lo: f64, mut hi: f64) -> f64 {
     const MAX_ITER: usize = 200;
     const EPS: f64 = 1e-12;
 
+    let mut width = (hi - lo).abs().max(1.0);
+    for _ in 0..MAX_ITER {
+        if cdf_fn(hi) >= p {
+            break;
+        }
+        lo = hi;
+        hi += width;
+        width *= 2.0;
+    }
+    let mut width = (hi - lo).abs().max(1.0);
+    for _ in 0..MAX_ITER {
+        if cdf_fn(lo) <= p {
+            break;
+        }
+        hi = lo;
+        lo -= width;
+        width *= 2.0;
+    }
+
     for _ in 0..MAX_ITER {
         let mid = 0.5 * (lo + hi);
-        if (hi - lo).abs() < EPS {
+        // Relative tolerance: far-tail quantiles can be huge and an absolute
+        // 1e-12 is then below one ulp (the loop would spin to MAX_ITER).
+        if (hi - lo).abs() < EPS * mid.abs().max(1.0) {
             return mid;
         }
         if cdf_fn(mid) < p {

--- a/src/utils/special_functions.rs
+++ b/src/utils/special_functions.rs
@@ -243,6 +243,64 @@ fn beta_cf(a: f64, b: f64, x: f64) -> f64 {
     h
 }
 
+// ── Noncentral Student-t CDF (Lenth 1989) ─────────────────────────────────────
+
+/// CDF of the noncentral t distribution: `P(T ≤ t)` with `df` degrees of
+/// freedom and noncentrality `nc`.
+///
+/// Lenth's series (Algorithm AS 243): with `x = t²/(t²+df)`,
+/// `P = Φ(−nc) + ½ Σⱼ [pⱼ·I_x(j+½, df/2) + qⱼ·I_x(j+1, df/2)]` where the
+/// Poisson-like weights `pⱼ`, `qⱼ` are computed by recurrence. This is the
+/// engine behind exact statistical power calculations
+/// (see [`crate::hypothesis_tests::power_t_test`]).
+pub fn noncentral_t_cdf(t: f64, df: f64, nc: f64) -> f64 {
+    debug_assert!(df > 0.0, "df must be positive");
+    // Symmetry reduces to t ≥ 0: P(T ≤ t; δ) = 1 − P(T ≤ −t; −δ).
+    if t < 0.0 {
+        return 1.0 - noncentral_t_cdf(-t, df, -nc);
+    }
+    let phi_neg_nc = 0.5 * crate::prob::erf::erfc_cody(nc / std::f64::consts::SQRT_2);
+    if t == 0.0 {
+        return phi_neg_nc;
+    }
+    let half_nc2 = 0.5 * nc * nc;
+    if half_nc2 > 700.0 {
+        // exp(−δ²/2) underflows; at |δ| > 37 the CDF is 0 or 1 to ~1e-300.
+        return if nc > 0.0 { 0.0 } else { 1.0 };
+    }
+
+    let x = t * t / (t * t + df);
+    let half_df = 0.5 * df;
+
+    // Weights by recurrence: p₀ = e^{−δ²/2}, q₀ = δ·e^{−δ²/2}·√(2/π).
+    let mut p_j = (-half_nc2).exp();
+    let mut q_j = nc * (-half_nc2).exp() * (2.0 / std::f64::consts::PI).sqrt();
+    let mut sum = 0.0_f64;
+    let mut j = 0usize;
+    loop {
+        let jf = j as f64;
+        let term = p_j * regularized_incomplete_beta(jf + 0.5, half_df, x)
+            + q_j * regularized_incomplete_beta(jf + 1.0, half_df, x);
+        sum += term;
+        // The Poisson weights peak near j ≈ δ²/2; only stop once past it.
+        if (jf > half_nc2 && term.abs() < 1e-14 * (sum.abs() + 1e-300)) || j > 2000 {
+            break;
+        }
+        p_j *= half_nc2 / (jf + 1.0);
+        q_j *= half_nc2 / (jf + 1.5);
+        j += 1;
+    }
+
+    (phi_neg_nc + 0.5 * sum).clamp(0.0, 1.0)
+}
+
+/// Survival function of the noncentral t: `P(T > t)`.
+pub fn noncentral_t_sf(t: f64, df: f64, nc: f64) -> f64 {
+    // Recompute on the mirrored side rather than 1 − cdf so small upper
+    // tails keep relative precision.
+    noncentral_t_cdf(-t, df, -nc)
+}
+
 // ── General inverse CDF via bisection ─────────────────────────────────────────
 
 /// Find x such that `cdf_fn(x) ≈ p` via bisection starting from `[lo, hi]`.

--- a/src/utils/special_functions.rs
+++ b/src/utils/special_functions.rs
@@ -265,8 +265,11 @@ pub fn noncentral_t_cdf(t: f64, df: f64, nc: f64) -> f64 {
     }
     let half_nc2 = 0.5 * nc * nc;
     if half_nc2 > 700.0 {
-        // exp(−δ²/2) underflows; at |δ| > 37 the CDF is 0 or 1 to ~1e-300.
-        return if nc > 0.0 { 0.0 } else { 1.0 };
+        // exp(−δ²/2) underflows the series weights. Fall back to the
+        // Abramowitz-Stegun 26.7.10 normal approximation, which keeps the
+        // t-dependence (a flat 0/1 return here was wrong for t ≈ δ).
+        let z = (t * (1.0 - 1.0 / (4.0 * df)) - nc) / (1.0 + t * t / (2.0 * df)).sqrt();
+        return (0.5 * crate::prob::erf::erfc_cody(-z / std::f64::consts::SQRT_2)).clamp(0.0, 1.0);
     }
 
     let x = t * t / (t * t + df);
@@ -350,6 +353,32 @@ pub fn newton_inverse_cdf(
         }
     }
 
+    // Linear bisection cannot resolve roots far below the bracket width:
+    // with lo pinned at 0, every root under ~1e-12 used to "converge" to
+    // the bracket edge (e.g. Gamma(0.01, 1) medians ~1e-31). Locate tiny
+    // roots' order of magnitude in log scale first.
+    if lo == 0.0 && hi > 0.0 {
+        let tiny = f64::MIN_POSITIVE;
+        if cdf_fn(tiny) >= p {
+            return tiny; // the root sits below the smallest positive double
+        }
+        let mut glo = tiny;
+        let mut ghi = hi;
+        for _ in 0..80 {
+            let mid = (0.5 * (glo.ln() + ghi.ln())).exp();
+            if cdf_fn(mid) < p {
+                glo = mid;
+            } else {
+                ghi = mid;
+            }
+            if ghi <= glo * (1.0 + 1e-12) {
+                return 0.5 * (glo + ghi);
+            }
+        }
+        lo = glo;
+        hi = ghi;
+    }
+
     let mut x = 0.5 * (lo + hi);
     for _ in 0..40 {
         let f = cdf_fn(x) - p;
@@ -364,11 +393,13 @@ pub fn newton_inverse_cdf(
             // Newton left the bracket (flat density, overshoot): bisect.
             x_new = 0.5 * (lo + hi);
         }
-        if (x_new - x).abs() <= EPS * x.abs().max(1.0) {
+        // Relative-only convergence — an absolute floor here is exactly
+        // what silently truncated sub-1e-12 roots.
+        if x_new == x || (x_new - x).abs() <= EPS * x_new.abs() {
             return x_new;
         }
         x = x_new;
-        if (hi - lo).abs() <= EPS * x.abs().max(1.0) {
+        if (hi - lo).abs() <= EPS * hi.abs().max(lo.abs()) {
             return x;
         }
     }

--- a/tests/review_regressions.rs
+++ b/tests/review_regressions.rs
@@ -1,0 +1,33 @@
+// quick repro checks via test
+#[test]
+fn review_major_repros() {
+    use rs_stats::Distribution;
+    use rs_stats::distributions::gamma_distribution::Gamma;
+    use rs_stats::distributions::student_t::StudentT;
+    use rs_stats::utils::special_functions::noncentral_t_cdf;
+
+    // MAJOR 1: tiny-shape Gamma quantiles (scipy: median = 4.4713e-31)
+    let g = Gamma::new(0.01, 1.0).unwrap();
+    let q50 = g.inverse_cdf(0.5).unwrap();
+    let q10 = g.inverse_cdf(0.1).unwrap();
+    let q1e6 = g.inverse_cdf(1e-6).unwrap();
+    println!("q50={q50:e} q10={q10:e} q1e-6={q1e6:e}");
+    assert!(q50 > 0.0 && q10 > 0.0 && q1e6 > 0.0);
+    assert!(
+        q1e6 < q10 && q10 < q50,
+        "quantiles must be distinct & ordered"
+    );
+    let back = g.cdf(q50).unwrap();
+    assert!((back - 0.5).abs() < 1e-9, "roundtrip cdf(q50) = {back}");
+
+    // MAJOR 2: nct with huge nc must keep t-dependence
+    let v = noncentral_t_cdf(50.0, 10.0, 40.0);
+    println!("nct(50,10,40) = {v}");
+    assert!((v - 0.7797).abs() < 0.01, "nct = {v}, scipy = 0.7797");
+    assert!(noncentral_t_cdf(-50.0, 10.0, 40.0) < 1e-10);
+
+    // MAJOR 3: StudentT p=0/1
+    let t = StudentT::new(0.0, 1.0, 5.0).unwrap();
+    assert_eq!(t.inverse_cdf(0.0).unwrap(), f64::NEG_INFINITY);
+    assert_eq!(t.inverse_cdf(1.0).unwrap(), f64::INFINITY);
+}


### PR DESCRIPTION
## Summary

12 commits taking the crate from v3.0.0 to v4.0.0. Full changelog in `CHANGELOG.md`; highlights:

### Correctness (phase 1 + review fixes)
- Deep-tail fixes everywhere: dynamic quantile brackets (StudentT ν<2, F(1,1)), exact `erfc`, large-n Binomial, sub-1e-12 quantiles (log-scale root bracketing), u64-edge combinatorics, `feature_importances` panic
- Degenerate inputs are typed errors instead of silent NaN/∞; non-finite parameters rejected in every constructor; explicit NaN policy in sorts/ranks
- Statistically correct Student-t confidence + prediction intervals in linear regression

### Performance (phases 2, 4 + follow-ups)
- Cody rational `erf`/`erfc` (−69% to −88%), O(1) discrete CDFs, single-pass `fit_all` (−24% to −75%), Newton quantiles, incremental decision-tree splits (4–25×), multi-accumulator reductions
- Sampling: ziggurat (Normal/LogNormal), Marsaglia-Tsang Gamma family, Knuth/PTRS Poisson, BINV Binomial, Gamma-Poisson NegBin — at or above numpy parity on 15/18 distributions

### Features (phases 3, 5 + « 4.0 bien complète »)
- `sample()`/`sample_n()` and exact `sf()` on all distributions
- 4 new distributions (Cauchy, Laplace, Pareto, Logistic) + `MultivariateNormal` (Cholesky)
- Mann-Whitney U, Wilcoxon, two-sample KS, Fisher exact, D'Agostino K², one-sided alternatives, Cohen's d, η², `p_adjust`
- `bootstrap_ci` + `permutation_test`; exact power analysis via a noncentral-t CDF
- Pearson/Spearman correlation, `describe()`/`quantile()`, per-coefficient inference in multiple regression
- Cargo features `parallel`/`serde` (default on); leaner dependency tree

### Breaking changes
See the **v4.0.0 section of CHANGELOG.md** — `ChiSquareResult` replaces tuples, `std_err` sample convention, `Exponential` domain alignment, typed errors for degenerate inputs, new public struct fields.

## Test plan
- 417 unit tests + 93 doc tests + integration regression tests (402 with `--no-default-features`)
- Local numeric cross-validation against scipy/numpy: 62/62 including hostile tail regimes (extreme quantiles, ν=0.5 Student-t, n=5000 binomials)
- criterion benchmarks before/after for every perf claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)